### PR TITLE
feat(#8): Engine builder + Plugin trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Engine` struct owning `World` + `Schedule` with a fluent builder API
+  (`add_system`, `add_plugin`, `insert_resource`) and `tick`/`run_once`
+  execution methods ([#8](https://github.com/galeon-engine/galeon/issues/8))
+- `Plugin` trait (`fn build(&self, engine: &mut Engine)`) for bundling systems
+  and resources into reusable units
+  ([#8](https://github.com/galeon-engine/galeon/issues/8))
+- `World::try_resource<T>()` — non-panicking resource probe returning
+  `Option<&T>`
+  ([#8](https://github.com/galeon-engine/galeon/issues/8))
+- `docs/guide/plugins.md` — guide covering the builder API and plugin system
+  ([#8](https://github.com/galeon-engine/galeon/issues/8))
 - Fixed-step game loop with time accumulator (default 10 Hz for RTS)
   ([#6](https://github.com/galeon-engine/galeon/issues/6))
 - RON data loading: `UnitTemplate`, `UnitStats`, `DataRegistry` for loading

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+use crate::game_loop::{self, FixedTimestep};
+use crate::schedule::{Schedule, SystemFn};
+use crate::world::World;
+
+/// The central game engine object.
+///
+/// `Engine` owns the [`World`] and [`Schedule`] and exposes a builder API for
+/// wiring up systems and plugins before (or during) the game loop.
+///
+/// # Example
+///
+/// ```rust
+/// use galeon_engine::{Engine, Plugin};
+///
+/// fn my_system(_world: &mut galeon_engine::World) {}
+///
+/// struct MyPlugin;
+/// impl Plugin for MyPlugin {
+///     fn build(&self, engine: &mut Engine) {
+///         engine.add_system("update", "my_system", my_system);
+///     }
+/// }
+///
+/// let mut engine = Engine::new();
+/// engine.add_plugin(MyPlugin);
+/// engine.run_once();
+/// ```
+pub struct Engine {
+    world: World,
+    schedule: Schedule,
+}
+
+impl Engine {
+    /// Create a new engine with an empty [`World`] and [`Schedule`].
+    pub fn new() -> Self {
+        Self {
+            world: World::new(),
+            schedule: Schedule::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    /// Immutable reference to the world.
+    pub fn world(&self) -> &World {
+        &self.world
+    }
+
+    /// Mutable reference to the world.
+    pub fn world_mut(&mut self) -> &mut World {
+        &mut self.world
+    }
+
+    /// Immutable reference to the schedule.
+    pub fn schedule(&self) -> &Schedule {
+        &self.schedule
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder API
+    // -------------------------------------------------------------------------
+
+    /// Add a system to the schedule.
+    ///
+    /// Delegates to [`Schedule::add_system`]. Returns `&mut Self` for chaining.
+    pub fn add_system(
+        &mut self,
+        stage: &'static str,
+        name: &'static str,
+        func: SystemFn,
+    ) -> &mut Self {
+        self.schedule.add_system(stage, name, func);
+        self
+    }
+
+    /// Apply a plugin to this engine.
+    ///
+    /// Calls [`Plugin::build`] with `self`. Returns `&mut Self` for chaining.
+    pub fn add_plugin(&mut self, plugin: impl Plugin) -> &mut Self {
+        plugin.build(self);
+        self
+    }
+
+    /// Insert a resource into the world.
+    ///
+    /// Delegates to [`World::insert_resource`]. Returns `&mut Self` for
+    /// chaining.
+    pub fn insert_resource<T: 'static>(&mut self, value: T) -> &mut Self {
+        self.world.insert_resource(value);
+        self
+    }
+
+    // -------------------------------------------------------------------------
+    // Execution
+    // -------------------------------------------------------------------------
+
+    /// Advance the simulation by `elapsed` seconds using a fixed timestep.
+    ///
+    /// If a [`FixedTimestep`] resource has not been inserted yet this method
+    /// inserts the default RTS timestep (10 Hz) automatically. Returns the
+    /// number of ticks executed.
+    pub fn tick(&mut self, elapsed: f64) -> u32 {
+        // Lazily insert the default timestep so callers don't have to.
+        if !self.has_timestep() {
+            self.world.insert_resource(FixedTimestep::default_rts());
+        }
+        game_loop::tick(&mut self.world, &self.schedule, elapsed)
+    }
+
+    /// Run the schedule exactly once without any fixed-timestep logic.
+    ///
+    /// Useful for integration tests or non-game-loop scenarios.
+    pub fn run_once(&mut self) {
+        self.schedule.run(&mut self.world);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /// Returns `true` if a [`FixedTimestep`] resource is already present.
+    fn has_timestep(&self) -> bool {
+        // We use a try-pattern by checking via a raw resource probe.
+        // `World::resource` panics, so we rely on the resource module's
+        // internal try_get once it is available. For now we track it via a
+        // small sentinel resource.
+        self.world
+            .try_resource::<FixedTimestep>()
+            .is_some()
+    }
+}
+
+impl Default for Engine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Plugin trait
+// =============================================================================
+
+/// A plugin encapsulates a cohesive set of systems and resources.
+///
+/// Implement this trait to bundle engine configuration into a reusable unit.
+///
+/// # Example
+///
+/// ```rust
+/// use galeon_engine::{Engine, Plugin, World};
+///
+/// fn physics_system(_world: &mut World) {}
+///
+/// pub struct PhysicsPlugin;
+///
+/// impl Plugin for PhysicsPlugin {
+///     fn build(&self, engine: &mut Engine) {
+///         engine.add_system("simulate", "physics", physics_system);
+///     }
+/// }
+/// ```
+pub trait Plugin {
+    /// Configure `engine` with this plugin's systems and resources.
+    fn build(&self, engine: &mut Engine);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Component;
+
+    #[derive(Debug)]
+    struct Counter(u32);
+    impl Component for Counter {}
+
+    fn increment(world: &mut World) {
+        for (_, c) in world.query_mut::<Counter>() {
+            c.0 += 1;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Engine::new / accessors
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn new_engine_has_empty_world_and_schedule() {
+        let engine = Engine::new();
+        assert_eq!(engine.world().entity_count(), 0);
+        assert_eq!(engine.schedule().system_count(), 0);
+    }
+
+    #[test]
+    fn world_mut_allows_mutation() {
+        let mut engine = Engine::new();
+        engine.world_mut().spawn((Counter(0),));
+        assert_eq!(engine.world().entity_count(), 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder API
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn add_system_registers_system() {
+        let mut engine = Engine::new();
+        engine.add_system("update", "increment", increment);
+        assert_eq!(engine.schedule().system_count(), 1);
+    }
+
+    #[test]
+    fn add_system_is_chainable() {
+        let mut engine = Engine::new();
+        engine
+            .add_system("pre", "increment", increment)
+            .add_system("post", "increment", increment);
+        assert_eq!(engine.schedule().system_count(), 2);
+    }
+
+    #[test]
+    fn insert_resource_is_chainable() {
+        struct Gravity(f32);
+
+        let mut engine = Engine::new();
+        engine.insert_resource(Gravity(9.8));
+        assert!((engine.world().resource::<Gravity>().0 - 9.8).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin
+    // -------------------------------------------------------------------------
+
+    struct IncrementPlugin;
+    impl Plugin for IncrementPlugin {
+        fn build(&self, engine: &mut Engine) {
+            engine.add_system("update", "increment", increment);
+        }
+    }
+
+    #[test]
+    fn add_plugin_calls_build() {
+        let mut engine = Engine::new();
+        engine.add_plugin(IncrementPlugin);
+        assert_eq!(engine.schedule().system_count(), 1);
+    }
+
+    #[test]
+    fn add_plugin_is_chainable() {
+        let mut engine = Engine::new();
+        engine.add_plugin(IncrementPlugin).add_plugin(IncrementPlugin);
+        assert_eq!(engine.schedule().system_count(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // run_once
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn run_once_executes_schedule() {
+        let mut engine = Engine::new();
+        engine.world_mut().spawn((Counter(0),));
+        engine.add_system("update", "increment", increment);
+        engine.run_once();
+
+        let counts: Vec<u32> = engine
+            .world()
+            .query::<Counter>()
+            .into_iter()
+            .map(|(_, c)| c.0)
+            .collect();
+        assert_eq!(counts, vec![1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // tick
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn tick_inserts_default_timestep_when_absent() {
+        let mut engine = Engine::new();
+        // No FixedTimestep inserted — tick should not panic.
+        let ticks = engine.tick(0.05); // 0.05 s < 0.1 s step → 0 ticks
+        assert_eq!(ticks, 0);
+    }
+
+    #[test]
+    fn tick_respects_existing_timestep() {
+        let mut engine = Engine::new();
+        // Use 10 Hz (0.1 s/tick) to avoid floating-point accumulation issues.
+        engine.world_mut().insert_resource(FixedTimestep::new(10.0));
+        engine.world_mut().spawn((Counter(0),));
+        engine.add_system("update", "increment", increment);
+
+        // 0.35 s at 10 Hz → 3 ticks (same as game_loop test)
+        let ticks = engine.tick(0.35);
+        assert_eq!(ticks, 3);
+
+        let counts: Vec<u32> = engine
+            .world()
+            .query::<Counter>()
+            .into_iter()
+            .map(|(_, c)| c.0)
+            .collect();
+        assert_eq!(counts, vec![3]);
+    }
+
+    #[test]
+    fn tick_returns_correct_tick_count() {
+        let mut engine = Engine::new();
+        // Default 10 Hz → 0.25 s yields 2 ticks
+        let ticks = engine.tick(0.25);
+        assert_eq!(ticks, 2);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -8,6 +8,7 @@ extern crate self as galeon_engine;
 
 pub mod component;
 pub mod data;
+pub mod engine;
 pub mod entity;
 pub mod game_loop;
 mod resource;
@@ -17,6 +18,7 @@ pub mod world;
 // Re-exports for ergonomic API.
 pub use component::Component;
 pub use data::{DataRegistry, UnitStats, UnitTemplate};
+pub use engine::{Engine, Plugin};
 pub use entity::Entity;
 pub use galeon_engine_macros::Component;
 pub use game_loop::FixedTimestep;

--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -98,6 +98,11 @@ impl World {
         self.resources.get_mut::<T>()
     }
 
+    /// Try to get a reference to a resource. Returns `None` if not present.
+    pub fn try_resource<T: 'static>(&self) -> Option<&T> {
+        self.resources.try_get::<T>()
+    }
+
     /// Remove and return a resource. Panics if not present.
     pub fn take_resource<T: 'static>(&mut self) -> T {
         self.resources.take::<T>()

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,181 @@
+# Engine, Builder API & Plugins
+
+The `Engine` struct is the entry point for a Galeon game. It owns the [`World`]
+(entities, components, resources) and the [`Schedule`] (systems), and exposes a
+fluent builder API for wiring everything up.
+
+## Creating an Engine
+
+```rust
+use galeon_engine::Engine;
+
+let mut engine = Engine::new();
+```
+
+## Adding Systems
+
+Systems are plain Rust functions `fn(&mut World)`. Register them with a stage
+name and a display name:
+
+```rust
+use galeon_engine::{Engine, World};
+
+fn move_units(world: &mut World) {
+    // query and mutate components here
+}
+
+let mut engine = Engine::new();
+engine.add_system("simulate", "move_units", move_units);
+```
+
+Calls are chainable:
+
+```rust
+engine
+    .add_system("pre", "input", input_system)
+    .add_system("simulate", "physics", physics_system)
+    .add_system("post", "render_sync", render_sync_system);
+```
+
+Stages run in the order they are first registered. Systems within the same
+stage run in registration order.
+
+## Inserting Resources
+
+Resources are world-global singletons (e.g. configuration, time, counters).
+
+```rust
+struct TickRate(f64);
+
+engine.insert_resource(TickRate(10.0));
+```
+
+This is also chainable with `add_system` and `add_plugin`.
+
+## Plugins
+
+A `Plugin` bundles related systems and resources into a reusable unit.
+
+```rust
+use galeon_engine::{Engine, Plugin, World};
+
+fn physics_system(_world: &mut World) {}
+fn collision_system(_world: &mut World) {}
+
+pub struct PhysicsPlugin;
+
+impl Plugin for PhysicsPlugin {
+    fn build(&self, engine: &mut Engine) {
+        engine
+            .add_system("simulate", "physics", physics_system)
+            .add_system("simulate", "collision", collision_system);
+    }
+}
+```
+
+Apply the plugin with `add_plugin`:
+
+```rust
+let mut engine = Engine::new();
+engine.add_plugin(PhysicsPlugin);
+```
+
+Multiple plugins can be chained:
+
+```rust
+engine
+    .add_plugin(PhysicsPlugin)
+    .add_plugin(AudioPlugin)
+    .add_plugin(NetworkPlugin);
+```
+
+## Running the Engine
+
+### Fixed-Timestep Game Loop
+
+`Engine::tick(elapsed)` advances the simulation by a fixed step. Pass the
+wall-clock delta since the last frame. If no [`FixedTimestep`] resource has
+been inserted, the default RTS rate (10 Hz) is used automatically.
+
+```rust
+// Somewhere in your platform loop:
+let ticks = engine.tick(delta_seconds);
+// `ticks` is the number of simulation steps executed this frame.
+```
+
+To use a custom tick rate, insert a [`FixedTimestep`] resource before the
+first call:
+
+```rust
+use galeon_engine::FixedTimestep;
+
+engine.insert_resource(FixedTimestep::new(30.0)); // 30 Hz
+```
+
+### Single-shot Execution
+
+For tests or tools that don't need a game loop, `run_once()` runs the schedule
+exactly once:
+
+```rust
+engine.run_once();
+```
+
+## Accessing World and Schedule
+
+```rust
+// Read entity count
+let count = engine.world().entity_count();
+
+// Spawn an entity
+engine.world_mut().spawn((Position { x: 0.0, y: 0.0 },));
+
+// Inspect registered systems
+let num_systems = engine.schedule().system_count();
+```
+
+## Full Example
+
+```rust
+use galeon_engine::{Engine, Plugin, World};
+
+// --- Components ---
+
+#[derive(galeon_engine::Component)]
+struct Position { x: f32, y: f32 }
+
+// --- Systems ---
+
+fn gravity(world: &mut World) {
+    // apply gravity to all entities with Position
+    for (_, pos) in world.query_mut::<Position>() {
+        pos.y -= 9.8 * 0.1; // step = 0.1 s at 10 Hz
+    }
+}
+
+// --- Plugin ---
+
+pub struct GravityPlugin;
+
+impl Plugin for GravityPlugin {
+    fn build(&self, engine: &mut Engine) {
+        engine.add_system("simulate", "gravity", gravity);
+    }
+}
+
+// --- Entry point ---
+
+fn main() {
+    let mut engine = Engine::new();
+    engine
+        .add_plugin(GravityPlugin)
+        .insert_resource(/* your config */());
+
+    engine.world_mut().spawn((Position { x: 0.0, y: 100.0 },));
+
+    // Fake game loop
+    for _ in 0..10 {
+        engine.tick(1.0 / 60.0); // 60 fps
+    }
+}
+```


### PR DESCRIPTION
Closes #8

## Summary

- **`Engine` struct** owning `World` + `Schedule` with fluent builder API (`add_system`, `add_plugin`, `insert_resource`) and `tick`/`run_once` execution methods
- **`Plugin` trait** (`fn build(&self, engine: &mut Engine)`) for bundling systems and resources into reusable units
- **`World::try_resource<T>()`** — non-panicking resource probe returning `Option<&T>`
- **`docs/guide/plugins.md`** — usage guide covering builder API and plugin system

## Tasks

- [x] **T1:** Engine struct owning World + Schedule [tier-1]
- [x] **T2:** Plugin trait with `build()` method [tier-1]
- [x] **T3:** Builder API: `add_system()`, `add_plugin()`, `insert_resource()` [tier-2]
- [x] **T4:** Docs at `docs/guide/plugins.md` [tier-2]

## Timeline

- [shiplog/session-start] Branch created, tasks scoped
- [shiplog/commit-note] `e33d10a` — all 4 tasks in single commit (tightly coupled)

## Verification

- `cargo check --workspace` — clean
- `cargo test --workspace` — 52 unit tests + 2 doctests, all pass
- `cargo clippy -- -D warnings` — zero warnings

## Provenance

- Orchestrated-by: claude/opus-4-6 (claude-code)
- Implemented-by: claude/sonnet-4-6 (claude-code, subagent)