### PR TITLE
feat(#12): Typed component storage — replace Box<dyn Any> with Vec<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Component storage now uses typed sparse sets (`Vec<T>`) instead of
+  type-erased `Vec<Box<dyn Any>>`, eliminating per-component heap allocation
+  and per-entity runtime downcasts on all hot paths
+  ([#12](https://github.com/galeon-engine/galeon/issues/12))
+
 ### Added
 
 - `Engine` struct owning `World` + `Schedule` with a fluent builder API

--- a/crates/engine/src/component.rs
+++ b/crates/engine/src/component.rs
@@ -8,22 +8,25 @@ use std::collections::HashMap;
 /// Derive with `#[derive(Component)]` from `galeon_engine_macros`.
 pub trait Component: 'static {}
 
-#[allow(dead_code)]
-/// Type-erased storage for a single component type, backed by a sparse set.
+// =============================================================================
+// TypedSparseSet<T> — typed, cache-friendly component storage
+// =============================================================================
+
+/// Typed storage for a single component type, backed by a sparse set.
 ///
+/// Stores components in a dense `Vec<T>` — no boxing, no runtime downcasts.
 /// Sparse set gives O(1) insert/get/remove and dense iteration — ideal for
 /// RTS entities that frequently gain/lose components.
-pub(crate) struct SparseSet {
+pub(crate) struct TypedSparseSet<T> {
     /// Sparse array: entity index → dense index (or `u32::MAX` if absent).
     sparse: Vec<u32>,
     /// Dense array of entity indices that have this component.
     dense: Vec<u32>,
-    /// Parallel to `dense`: the actual component data (type-erased).
-    data: Vec<Box<dyn Any>>,
+    /// Parallel to `dense`: the actual component data (typed, no Box).
+    data: Vec<T>,
 }
 
-#[allow(dead_code)]
-impl SparseSet {
+impl<T> TypedSparseSet<T> {
     pub fn new() -> Self {
         Self {
             sparse: Vec::new(),
@@ -33,7 +36,7 @@ impl SparseSet {
     }
 
     /// Insert a component for an entity. Overwrites if already present.
-    pub fn insert(&mut self, entity_index: u32, value: Box<dyn Any>) {
+    pub fn insert(&mut self, entity_index: u32, value: T) {
         let idx = entity_index as usize;
 
         // Grow sparse array if needed.
@@ -55,22 +58,22 @@ impl SparseSet {
     }
 
     /// Get a reference to the component for an entity.
-    pub fn get(&self, entity_index: u32) -> Option<&dyn Any> {
+    pub fn get(&self, entity_index: u32) -> Option<&T> {
         let idx = entity_index as usize;
         if idx < self.sparse.len() && self.sparse[idx] != u32::MAX {
             let dense_idx = self.sparse[idx] as usize;
-            Some(&*self.data[dense_idx])
+            Some(&self.data[dense_idx])
         } else {
             None
         }
     }
 
     /// Get a mutable reference to the component for an entity.
-    pub fn get_mut(&mut self, entity_index: u32) -> Option<&mut dyn Any> {
+    pub fn get_mut(&mut self, entity_index: u32) -> Option<&mut T> {
         let idx = entity_index as usize;
         if idx < self.sparse.len() && self.sparse[idx] != u32::MAX {
             let dense_idx = self.sparse[idx] as usize;
-            Some(&mut *self.data[dense_idx])
+            Some(&mut self.data[dense_idx])
         } else {
             None
         }
@@ -103,40 +106,79 @@ impl SparseSet {
     }
 
     /// Returns `true` if this entity has the component.
+    #[allow(dead_code)]
     pub fn contains(&self, entity_index: u32) -> bool {
         let idx = entity_index as usize;
         idx < self.sparse.len() && self.sparse[idx] != u32::MAX
     }
 
     /// Returns the number of entities that have this component.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.dense.len()
     }
 
-    /// Returns an iterator over (entity_index, &dyn Any) pairs.
-    pub fn iter(&self) -> impl Iterator<Item = (u32, &dyn Any)> {
+    /// Returns an iterator over (entity_index, &T) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (u32, &T)> {
         self.dense
             .iter()
             .zip(self.data.iter())
-            .map(|(&entity_idx, data)| (entity_idx, &**data))
+            .map(|(&entity_idx, data)| (entity_idx, data))
     }
 
-    /// Returns an iterator over (entity_index, &mut dyn Any) pairs.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (u32, &mut dyn Any)> {
+    /// Returns an iterator over (entity_index, &mut T) pairs.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (u32, &mut T)> {
         self.dense
             .iter()
             .zip(self.data.iter_mut())
-            .map(|(&entity_idx, data)| (entity_idx, &mut **data))
+            .map(|(&entity_idx, data)| (entity_idx, data))
     }
 }
 
-#[allow(dead_code)]
-/// Registry of all component sparse sets, keyed by `TypeId`.
-pub(crate) struct ComponentStorage {
-    sets: HashMap<TypeId, SparseSet>,
+// =============================================================================
+// AnyComponentStore — type erasure at the registry level
+// =============================================================================
+
+/// Trait object interface for component stores in the registry.
+///
+/// This allows `ComponentStorage` to hold heterogeneous `TypedSparseSet<T>`
+/// values in a single `HashMap` while still supporting operations like
+/// `remove_all` that don't need the concrete type.
+pub(crate) trait AnyComponentStore: Any {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn remove_entry(&mut self, entity_index: u32) -> bool;
 }
 
-#[allow(dead_code)]
+impl<T: 'static> AnyComponentStore for TypedSparseSet<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn remove_entry(&mut self, entity_index: u32) -> bool {
+        self.remove(entity_index)
+    }
+}
+
+// =============================================================================
+// ComponentStorage — typed registry keyed by TypeId
+// =============================================================================
+
+/// Registry of all component sparse sets, keyed by `TypeId`.
+///
+/// Stores `Box<dyn AnyComponentStore>` internally but provides typed access
+/// via `typed_set` / `typed_set_mut` methods. The downcast from the trait
+/// object happens once per query call (at the storage level), not once per
+/// entity — a major improvement over the previous `Box<dyn Any>` per-component
+/// design.
+pub(crate) struct ComponentStorage {
+    sets: HashMap<TypeId, Box<dyn AnyComponentStore>>,
+}
+
 impl ComponentStorage {
     pub fn new() -> Self {
         Self {
@@ -144,107 +186,113 @@ impl ComponentStorage {
         }
     }
 
-    /// Get or create the sparse set for a component type.
-    pub fn set_mut<T: Component>(&mut self) -> &mut SparseSet {
+    /// Get the typed sparse set for a component type (read-only).
+    ///
+    /// Returns `None` if no entities have this component type.
+    pub fn typed_set<T: Component>(&self) -> Option<&TypedSparseSet<T>> {
+        self.sets
+            .get(&TypeId::of::<T>())
+            .and_then(|s| s.as_any().downcast_ref::<TypedSparseSet<T>>())
+    }
+
+    /// Get or create the typed sparse set for a component type (mutable).
+    pub fn typed_set_mut<T: Component>(&mut self) -> &mut TypedSparseSet<T> {
         self.sets
             .entry(TypeId::of::<T>())
-            .or_insert_with(SparseSet::new)
-    }
-
-    /// Get the sparse set for a component type (read-only).
-    pub fn set<T: Component>(&self) -> Option<&SparseSet> {
-        self.sets.get(&TypeId::of::<T>())
-    }
-
-    /// Get the sparse set for a given TypeId (read-only).
-    pub fn set_by_id(&self, type_id: TypeId) -> Option<&SparseSet> {
-        self.sets.get(&type_id)
-    }
-
-    /// Get the sparse set for a given TypeId (mutable).
-    pub fn set_by_id_mut(&mut self, type_id: TypeId) -> Option<&mut SparseSet> {
-        self.sets.get_mut(&type_id)
+            .or_insert_with(|| Box::new(TypedSparseSet::<T>::new()))
+            .as_any_mut()
+            .downcast_mut::<TypedSparseSet<T>>()
+            .expect("TypeId mismatch in component storage")
     }
 
     /// Remove all components for a given entity index.
     pub fn remove_all(&mut self, entity_index: u32) {
         for set in self.sets.values_mut() {
-            set.remove(entity_index);
+            set.remove_entry(entity_index);
         }
     }
 
-    /// Get two mutable sparse sets at once (for queries needing mutable access to multiple components).
-    /// Panics if `a == b`.
-    pub fn sets_two_mut(
+    /// Get two mutable typed sparse sets at once.
+    ///
+    /// Panics if `A` and `B` are the same type.
+    pub fn typed_sets_two_mut<A: Component, B: Component>(
         &mut self,
-        a: TypeId,
-        b: TypeId,
-    ) -> (Option<&mut SparseSet>, Option<&mut SparseSet>) {
-        assert_ne!(a, b, "cannot borrow the same sparse set mutably twice");
+    ) -> (
+        Option<&mut TypedSparseSet<A>>,
+        Option<&mut TypedSparseSet<B>>,
+    ) {
+        assert_ne!(
+            TypeId::of::<A>(),
+            TypeId::of::<B>(),
+            "cannot borrow the same sparse set mutably twice"
+        );
 
-        let ptr = &mut self.sets as *mut HashMap<TypeId, SparseSet>;
-        // SAFETY: We asserted a != b, so we're borrowing two distinct entries.
+        let ptr = &mut self.sets as *mut HashMap<TypeId, Box<dyn AnyComponentStore>>;
+        // SAFETY: We asserted A != B, so we're borrowing two distinct entries.
         unsafe {
-            let set_a = (*ptr).get_mut(&a);
-            let set_b = (*ptr).get_mut(&b);
+            let set_a = (*ptr)
+                .get_mut(&TypeId::of::<A>())
+                .and_then(|s| s.as_any_mut().downcast_mut::<TypedSparseSet<A>>());
+            let set_b = (*ptr)
+                .get_mut(&TypeId::of::<B>())
+                .and_then(|s| s.as_any_mut().downcast_mut::<TypedSparseSet<B>>());
             (set_a, set_b)
         }
     }
 }
+
+// =============================================================================
+// Tests
+// =============================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn sparse_set_insert_get() {
-        let mut set = SparseSet::new();
-        set.insert(5, Box::new(42_i32));
-        let val = set.get(5).unwrap().downcast_ref::<i32>().unwrap();
-        assert_eq!(*val, 42);
+    fn typed_sparse_set_insert_get() {
+        let mut set = TypedSparseSet::new();
+        set.insert(5, 42_i32);
+        assert_eq!(*set.get(5).unwrap(), 42);
     }
 
     #[test]
-    fn sparse_set_overwrite() {
-        let mut set = SparseSet::new();
-        set.insert(0, Box::new(1_i32));
-        set.insert(0, Box::new(2_i32));
-        let val = set.get(0).unwrap().downcast_ref::<i32>().unwrap();
-        assert_eq!(*val, 2);
+    fn typed_sparse_set_overwrite() {
+        let mut set = TypedSparseSet::new();
+        set.insert(0, 1_i32);
+        set.insert(0, 2_i32);
+        assert_eq!(*set.get(0).unwrap(), 2);
         assert_eq!(set.len(), 1);
     }
 
     #[test]
-    fn sparse_set_remove() {
-        let mut set = SparseSet::new();
-        set.insert(0, Box::new(10_i32));
-        set.insert(1, Box::new(20_i32));
-        set.insert(2, Box::new(30_i32));
+    fn typed_sparse_set_remove() {
+        let mut set = TypedSparseSet::new();
+        set.insert(0, 10_i32);
+        set.insert(1, 20_i32);
+        set.insert(2, 30_i32);
         assert!(set.remove(1));
         assert!(!set.contains(1));
         assert_eq!(set.len(), 2);
 
         // Remaining elements are still accessible.
-        assert_eq!(*set.get(0).unwrap().downcast_ref::<i32>().unwrap(), 10);
-        assert_eq!(*set.get(2).unwrap().downcast_ref::<i32>().unwrap(), 30);
+        assert_eq!(*set.get(0).unwrap(), 10);
+        assert_eq!(*set.get(2).unwrap(), 30);
     }
 
     #[test]
-    fn sparse_set_remove_nonexistent_returns_false() {
-        let mut set = SparseSet::new();
+    fn typed_sparse_set_remove_nonexistent_returns_false() {
+        let mut set = TypedSparseSet::<i32>::new();
         assert!(!set.remove(99));
     }
 
     #[test]
-    fn sparse_set_iteration() {
-        let mut set = SparseSet::new();
-        set.insert(3, Box::new(30_i32));
-        set.insert(7, Box::new(70_i32));
+    fn typed_sparse_set_iteration() {
+        let mut set = TypedSparseSet::new();
+        set.insert(3, 30_i32);
+        set.insert(7, 70_i32);
 
-        let items: Vec<_> = set
-            .iter()
-            .map(|(idx, val)| (idx, *val.downcast_ref::<i32>().unwrap()))
-            .collect();
+        let items: Vec<_> = set.iter().map(|(idx, &val)| (idx, val)).collect();
         assert_eq!(items.len(), 2);
         assert!(items.contains(&(3, 30)));
         assert!(items.contains(&(7, 70)));

--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 
-use std::any::TypeId;
-
-use crate::component::{Component, ComponentStorage, SparseSet};
+use crate::component::{Component, ComponentStorage, TypedSparseSet};
 use crate::entity::{Entity, EntityAllocator};
 use crate::resource::Resources;
 
@@ -17,9 +15,7 @@ pub trait Bundle {
 // Implement Bundle for single component.
 impl<A: Component> Bundle for (A,) {
     fn insert_into(self, storage: &mut ComponentStorage, entity_index: u32) {
-        storage
-            .set_mut::<A>()
-            .insert(entity_index, Box::new(self.0));
+        storage.typed_set_mut::<A>().insert(entity_index, self.0);
     }
 }
 
@@ -30,7 +26,7 @@ macro_rules! impl_bundle {
         impl<$($t: Component),+> Bundle for ($($t,)+) {
             fn insert_into(self, storage: &mut ComponentStorage, entity_index: u32) {
                 let ($($t,)+) = self;
-                $(storage.set_mut::<$t>().insert(entity_index, Box::new($t));)+
+                $(storage.typed_set_mut::<$t>().insert(entity_index, $t);)+
             }
         }
     };
@@ -113,10 +109,7 @@ impl World {
         if !self.entities.is_alive(entity) {
             return None;
         }
-        self.components
-            .set::<T>()
-            .and_then(|s| s.get(entity.index))
-            .and_then(|v| v.downcast_ref::<T>())
+        self.components.typed_set::<T>()?.get(entity.index)
     }
 
     /// Get a mutable component for an entity.
@@ -124,56 +117,47 @@ impl World {
         if !self.entities.is_alive(entity) {
             return None;
         }
-        self.components
-            .set_mut::<T>()
-            .get_mut(entity.index)
-            .and_then(|v| v.downcast_mut::<T>())
+        self.components.typed_set_mut::<T>().get_mut(entity.index)
     }
 
     /// Query all entities that have component T (immutable).
     ///
     /// Returns an iterator of `(Entity, &T)` pairs.
     pub fn query<T: Component>(&self) -> Vec<(Entity, &T)> {
-        let Some(set) = self.components.set::<T>() else {
+        let Some(set) = self.components.typed_set::<T>() else {
             return Vec::new();
         };
         set.iter()
-            .filter_map(|(idx, any)| {
-                let val = any.downcast_ref::<T>()?;
-                Some((self.entities.entity_at(idx)?, val))
-            })
+            .filter_map(|(idx, val)| Some((self.entities.entity_at(idx)?, val)))
             .collect()
     }
 
     /// Query all entities that have component T (mutable).
     ///
     /// Returns a `Vec` since we can't return iterators over `&mut` with
-    /// the current type-erased storage without GATs or complex lifetime tricks.
+    /// the current storage model without GATs or complex lifetime tricks.
     pub fn query_mut<T: Component>(&mut self) -> Vec<(Entity, &mut T)> {
         let entities = &self.entities;
-        let set = self.components.set_mut::<T>();
+        let set = self.components.typed_set_mut::<T>();
         set.iter_mut()
-            .filter_map(|(idx, any)| {
-                let val = any.downcast_mut::<T>()?;
-                Some((entities.entity_at(idx)?, val))
-            })
+            .filter_map(|(idx, val)| Some((entities.entity_at(idx)?, val)))
             .collect()
     }
 
     /// Query all entities with two components (both immutable).
     pub fn query2<A: Component, B: Component>(&self) -> Vec<(Entity, &A, &B)> {
-        let (Some(set_a), Some(set_b)) = (self.components.set::<A>(), self.components.set::<B>())
-        else {
+        let (Some(set_a), Some(set_b)) = (
+            self.components.typed_set::<A>(),
+            self.components.typed_set::<B>(),
+        ) else {
             return Vec::new();
         };
 
         // Iterate the first set and probe the second.
         set_a
             .iter()
-            .filter_map(|(idx, a_any)| {
-                let b_any = set_b.get(idx)?;
-                let a = a_any.downcast_ref::<A>()?;
-                let b = b_any.downcast_ref::<B>()?;
+            .filter_map(|(idx, a)| {
+                let b = set_b.get(idx)?;
                 Some((self.entities.entity_at(idx)?, a, b))
             })
             .collect()
@@ -182,20 +166,18 @@ impl World {
     /// Query all entities with two components (both mutable).
     pub fn query2_mut<A: Component, B: Component>(&mut self) -> Vec<(Entity, &mut A, &mut B)> {
         let entities = &self.entities;
-        let (set_a, set_b) = self
-            .components
-            .sets_two_mut(TypeId::of::<A>(), TypeId::of::<B>());
+        let (set_a, set_b) = self.components.typed_sets_two_mut::<A, B>();
         let (Some(sa), Some(sb)) = (set_a, set_b) else {
             return Vec::new();
         };
 
         sa.iter_mut()
-            .filter_map(|(idx, a_any)| {
-                // SAFETY: sa and sb are distinct sparse sets (enforced by sets_two_mut).
-                let sb_ptr = sb as *mut SparseSet;
-                let b_any = unsafe { (*sb_ptr).get_mut(idx)? };
-                let a = a_any.downcast_mut::<A>()?;
-                let b = b_any.downcast_mut::<B>()?;
+            .filter_map(|(idx, a)| {
+                // SAFETY: sa and sb are distinct typed sparse sets (enforced by
+                // typed_sets_two_mut's TypeId assertion). Each entity index maps
+                // to a unique dense slot, so repeated get_mut calls never alias.
+                let sb_ptr = sb as *mut TypedSparseSet<B>;
+                let b = unsafe { (*sb_ptr).get_mut(idx)? };
                 Some((entities.entity_at(idx)?, a, b))
             })
             .collect()

--- a/docs/guide/ecs.md
+++ b/docs/guide/ecs.md
@@ -130,3 +130,28 @@ schedule.run(&mut world);
 
 The three-stage model (`input` → `simulate` → `sync`) ensures input is
 processed before simulation, and simulation completes before rendering sync.
+
+## Storage Internals
+
+Components are stored in **typed sparse sets** — each component type gets its
+own `Vec<T>` (no boxing, no `dyn Any`). This means:
+
+- **Zero heap allocation per component** — data lives in a contiguous `Vec<T>`
+- **Zero runtime downcasts on hot paths** — queries iterate typed data directly
+- **O(1) insert/get/remove** — sparse set semantics
+- **Dense iteration** — ideal for systems that touch many entities
+
+The type erasure needed for the component registry happens once per query call
+(at the storage level), not once per entity. This is a single `TypeId`
+comparison — negligible compared to the old design which boxed every component
+and downcast on every access.
+
+### Hot vs Cold Storage
+
+| Storage Class | Use For | Why |
+|---------------|---------|-----|
+| **Hot** (typed sparse set, default) | Transforms, movement, health, combat state, AI state | Iterated every tick, must be cache-friendly |
+| **Cold** (future: separate store) | Names, debug tags, editor metadata | Rarely iterated, should not pollute hot storage |
+
+Currently all components use typed sparse sets. Cold/sparse-side storage for
+editor metadata is a planned future addition.


### PR DESCRIPTION
Closes #12

## Summary

- **`TypedSparseSet<T>`** replaces the old type-erased `SparseSet` — stores components in `Vec<T>` instead of `Vec<Box<dyn Any>>`
- **`AnyComponentStore` trait** provides type erasure at the registry level only (one downcast per query call, not per entity)
- **All `Bundle` impls** updated — no more `Box::new()` on spawn
- **All `World` query/get methods** updated — no more `downcast_ref`/`downcast_mut` per entity
- **Public API unchanged** — `World` method signatures are identical
- **Docs** updated (`docs/guide/ecs.md` storage internals section, `CHANGELOG.md`)

## Tasks

- [x] **T1:** Define storage classes: hot table-backed components vs cold/sparse-side components [tier-1]
- [x] **T2:** Replace hot-path `Box<dyn Any>` access for the first core component set [tier-1]
- [x] **T3:** Ensure typed queries operate on typed storage with no runtime downcast in hot loops [tier-1]
- [x] **T4:** Add a narrow compatibility layer if needed so the existing API can migrate incrementally [tier-2] — not needed, public API unchanged
- [ ] **T5:** Benchmark: old erased storage vs new typed storage on representative entity counts [tier-2] — deferred to follow-up issue
- [x] **T6:** Document which components belong in hot storage and which belong in cold/sparse-side storage [tier-2]

## Timeline

- [shiplog/session-start] Branch created, tasks scoped
- [shiplog/commit-note] `873c499` — typed storage swap (component.rs, world.rs, ecs.md, CHANGELOG.md)

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — zero warnings
- `cargo test --workspace` — 52 unit tests + 2 doctests, all pass
- `cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync` — clean

## Unsafe Inventory

2 unsafe blocks remain (same count as before, now typed):

1. `ComponentStorage::typed_sets_two_mut` — raw pointer for two distinct HashMap entries
2. `World::query2_mut` closure — raw pointer to second set for repeated `get_mut` (each index unique)

## Provenance

- Orchestrated-by: claude/opus-4-6 (claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)