### PR TITLE
test(#19): query2_mut regression tests for unsafe borrow path

### DIFF
--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -309,4 +309,53 @@ mod tests {
         assert_eq!(results[0].1.x, 2.0);
         assert_eq!(results[0].2.x, 5.0);
     }
+
+    #[test]
+    fn query2_mut_mutates_both_components() {
+        let mut world = World::new();
+        let e1 = world.spawn((Pos { x: 1.0, y: 1.0 }, Vel { x: 10.0, y: 10.0 }));
+        let e2 = world.spawn((Pos { x: 2.0, y: 2.0 }, Vel { x: 20.0, y: 20.0 }));
+        let e3 = world.spawn((Pos { x: 3.0, y: 3.0 }, Vel { x: 30.0, y: 30.0 }));
+
+        for (_, pos, vel) in world.query2_mut::<Pos, Vel>() {
+            pos.x += 100.0;
+            vel.y += 200.0;
+        }
+
+        assert_eq!(world.get::<Pos>(e1).unwrap().x, 101.0);
+        assert_eq!(world.get::<Vel>(e1).unwrap().y, 210.0);
+        assert_eq!(world.get::<Pos>(e2).unwrap().x, 102.0);
+        assert_eq!(world.get::<Vel>(e2).unwrap().y, 220.0);
+        assert_eq!(world.get::<Pos>(e3).unwrap().x, 103.0);
+        assert_eq!(world.get::<Vel>(e3).unwrap().y, 230.0);
+    }
+
+    #[test]
+    fn query2_mut_skips_entities_missing_one_component() {
+        let mut world = World::new();
+        let e1 = world.spawn((Pos { x: 5.0, y: 5.0 },));
+        let e2 = world.spawn((Pos { x: 7.0, y: 7.0 }, Vel { x: 9.0, y: 9.0 }));
+        let e3 = world.spawn((Vel { x: 11.0, y: 11.0 },));
+
+        let results = world.query2_mut::<Pos, Vel>();
+        assert_eq!(results.len(), 1);
+
+        let (entity, pos, vel) = &results[0];
+        assert_eq!(*entity, e2);
+        assert_eq!(pos.x, 7.0);
+        assert_eq!(vel.x, 9.0);
+
+        // e1's Pos must be unchanged.
+        assert_eq!(world.get::<Pos>(e1).unwrap().x, 5.0);
+        // e3's Vel must be unchanged.
+        assert_eq!(world.get::<Vel>(e3).unwrap().x, 11.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot borrow the same sparse set mutably twice")]
+    fn query2_mut_same_type_panics() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 0.0, y: 0.0 },));
+        world.query2_mut::<Pos, Pos>();
+    }
 }


### PR DESCRIPTION
## Summary

- Add 3 regression tests for the `query2_mut` unsafe raw-pointer borrowing path in `World`
- Cover happy-path mutation, sparse membership misses, and same-type panic contract
- Closes all 3 tasks from issue #19

Closes #19

## Journey Timeline

### Initial Plan

Issue #19 identified that `query2_mut` relies on an unsafe raw-pointer access after the typed storage refactor in PR #18, with no dedicated regression coverage. Three tasks were scoped: happy-path mutation, sparse miss coverage, and panic contract test.

### What We Discovered

The existing test suite covered `query2` (immutable) thoroughly but had zero coverage for the mutable two-component query. The unsafe `sb_ptr` dereference in `query2_mut` depends on invariants from `ComponentStorage::typed_sets_two_mut` that could silently break with future layout changes.

### Key Decisions Made

| Decision | Rationale |
|----------|-----------|
| Tests only, no impl changes | The unsafe code is sound by inspection; the gap was coverage, not correctness |
| `#[should_panic]` for same-type | Documents the panic contract explicitly as a regression guard |
| 3-entity test fixtures | Exercises the sparse set intersection across multiple entities for both hits and misses |

### Changes Made

| Commit | Description |
|--------|-------------|
| `8145be4` | `test(#19): add query2_mut regression tests for unsafe borrow path` |

## Testing

- [x] `cargo test -p galeon-engine -- query2_mut` — 3/3 pass
- [x] `query2_mut_mutates_both_components` — verifies mutations land on correct entities
- [x] `query2_mut_skips_entities_missing_one_component` — exercises second-store lookup misses
- [x] `query2_mut_same_type_panics` — `#[should_panic]` guards the aliasing invariant

## Knowledge for Future Reference

- Any change to `ComponentStorage::typed_sets_two_mut` or `World::query2_mut` that breaks the aliasing invariant will now fail loudly via `query2_mut_same_type_panics`
- The sparse membership test pattern (entities with partial component sets) is reusable for future N-component query coverage

---
Authored-by: claude/opus-4.6 (claude-code)
*Captain's log -- PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
