### PR TITLE
feat(#32): restore lazy iterator parity wrappers [stack: #29]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ([#29](https://github.com/galeon-engine/galeon/issues/29))
 - `With<T>` / `Without<T>` archetype filters
   ([#29](https://github.com/galeon-engine/galeon/issues/29))
+- `World::query2`, `query2_mut`, `query3`, and `query3_mut` convenience wrappers plus exact `size_hint` support on archetype query iterators
+  ([#32](https://github.com/galeon-engine/galeon/issues/32))
 
 ### Removed
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -40,7 +40,8 @@ pub use manifest::{
 };
 pub use protocol::{Command, Dto, Event, ProtocolKind, ProtocolMeta, Query};
 pub use query::{
-    NoFilter, QueryFilter, QueryIter, QueryIterMut, QuerySpec, QuerySpecMut, With, Without,
+    NoFilter, Query2Iter, Query2MutIter, Query3Iter, Query3MutIter, QueryFilter, QueryIter,
+    QueryIterMut, QuerySpec, QuerySpecMut, With, Without,
 };
 pub use render::{MaterialHandle, MeshHandle, Transform, Visibility};
 pub use schedule::Schedule;

--- a/crates/engine/src/query.rs
+++ b/crates/engine/src/query.rs
@@ -126,6 +126,21 @@ where
             _filter: PhantomData,
         }
     }
+
+    fn remaining(&self) -> usize {
+        let current = self
+            .current
+            .as_ref()
+            .map_or(0, |state| Q::len(state) - self.row);
+        let future: usize = self
+            .store
+            .iter()
+            .skip(self.archetype_index)
+            .filter(|archetype| Q::matches(archetype.layout()) && F::matches(archetype.layout()))
+            .map(|archetype| archetype.len())
+            .sum();
+        current + future
+    }
 }
 
 impl<'w, Q, F> Iterator for QueryIter<'w, Q, F>
@@ -156,6 +171,21 @@ where
             self.current = Q::init_state(archetype);
             self.row = 0;
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.remaining();
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'w, Q, F> ExactSizeIterator for QueryIter<'w, Q, F>
+where
+    Q: QuerySpec + 'w,
+    F: QueryFilter,
+{
+    fn len(&self) -> usize {
+        self.remaining()
     }
 }
 
@@ -189,6 +219,22 @@ where
             _filter: PhantomData,
             _marker: PhantomData,
         }
+    }
+
+    fn remaining(&self) -> usize {
+        let current = self
+            .current
+            .as_ref()
+            .map_or(0, |state| Q::len(state) - self.row);
+        // SAFETY: The iterator owns the mutable store borrow for its entire
+        // lifetime, and this helper only reads future archetype metadata.
+        let future: usize = unsafe { &*self.store }
+            .iter()
+            .skip(self.archetype_index)
+            .filter(|archetype| Q::matches(archetype.layout()) && F::matches(archetype.layout()))
+            .map(|archetype| archetype.len())
+            .sum();
+        current + future
     }
 }
 
@@ -241,7 +287,28 @@ where
             self.row = 0;
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.remaining();
+        (remaining, Some(remaining))
+    }
 }
+
+impl<'w, Q, F> ExactSizeIterator for QueryIterMut<'w, Q, F>
+where
+    Q: QuerySpecMut + 'w,
+    F: QueryFilter,
+{
+    fn len(&self) -> usize {
+        self.remaining()
+    }
+}
+
+pub type Query2Iter<'w, A, B, F = NoFilter> = QueryIter<'w, (&'w A, &'w B), F>;
+pub type Query2MutIter<'w, A, B, F = NoFilter> = QueryIterMut<'w, (&'w mut A, &'w mut B), F>;
+pub type Query3Iter<'w, A, B, C, F = NoFilter> = QueryIter<'w, (&'w A, &'w B, &'w C), F>;
+pub type Query3MutIter<'w, A, B, C, F = NoFilter> =
+    QueryIterMut<'w, (&'w mut A, &'w mut B, &'w mut C), F>;
 
 #[doc(hidden)]
 pub struct SingleMutState<'w, T> {

--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -5,7 +5,10 @@ use std::any::TypeId;
 use crate::archetype::{ArchetypeLayout, ArchetypeStore, EntityLocation};
 use crate::component::Component;
 use crate::entity::{Entity, EntityMetaStore};
-use crate::query::{QueryFilter, QueryIter, QueryIterMut, QuerySpec, QuerySpecMut};
+use crate::query::{
+    Query2Iter, Query2MutIter, Query3Iter, Query3MutIter, QueryFilter, QueryIter, QueryIterMut,
+    QuerySpec, QuerySpecMut,
+};
 use crate::resource::Resources;
 
 // =============================================================================
@@ -411,6 +414,48 @@ impl World {
         &mut self,
     ) -> QueryIterMut<'_, Q, F> {
         QueryIterMut::new(&mut self.archetypes)
+    }
+
+    /// Convenience wrapper for two-component immutable queries.
+    pub fn query2<A: Component, B: Component>(&self) -> Query2Iter<'_, A, B> {
+        self.query::<(&A, &B)>()
+    }
+
+    /// Convenience wrapper for two-component mutable queries.
+    pub fn query2_mut<A: Component, B: Component>(&mut self) -> Query2MutIter<'_, A, B> {
+        assert_ne!(
+            TypeId::of::<A>(),
+            TypeId::of::<B>(),
+            "cannot borrow the same column mutably twice"
+        );
+        self.query_mut::<(&mut A, &mut B)>()
+    }
+
+    /// Convenience wrapper for three-component immutable queries.
+    pub fn query3<A: Component, B: Component, C: Component>(&self) -> Query3Iter<'_, A, B, C> {
+        self.query::<(&A, &B, &C)>()
+    }
+
+    /// Convenience wrapper for three-component mutable queries.
+    pub fn query3_mut<A: Component, B: Component, C: Component>(
+        &mut self,
+    ) -> Query3MutIter<'_, A, B, C> {
+        assert_ne!(
+            TypeId::of::<A>(),
+            TypeId::of::<B>(),
+            "cannot borrow the same column mutably twice"
+        );
+        assert_ne!(
+            TypeId::of::<A>(),
+            TypeId::of::<C>(),
+            "cannot borrow the same column mutably twice"
+        );
+        assert_ne!(
+            TypeId::of::<B>(),
+            TypeId::of::<C>(),
+            "cannot borrow the same column mutably twice"
+        );
+        self.query_mut::<(&mut A, &mut B, &mut C)>()
     }
 
     /// Returns the number of alive entities.

--- a/crates/engine/tests/query_iter.rs
+++ b/crates/engine/tests/query_iter.rs
@@ -103,6 +103,21 @@ fn query2_empty_when_no_overlap() {
 }
 
 #[test]
+fn query2_wrapper_matches_generic_query() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 }, Vel { dx: 5.0, dy: 0.0 }));
+    world.spawn((Pos { x: 2.0, y: 0.0 },));
+
+    let generic: Vec<_> = world.query::<(&Pos, &Vel)>().collect();
+    let wrapper: Vec<_> = world.query2::<Pos, Vel>().collect();
+
+    assert_eq!(generic.len(), wrapper.len());
+    assert_eq!(generic[0].0, wrapper[0].0);
+    assert_eq!(generic[0].1.0.x, wrapper[0].1.0.x);
+    assert_eq!(generic[0].1.1.dx, wrapper[0].1.1.dx);
+}
+
+#[test]
 fn query2_mut_mutates_both() {
     let mut world = World::new();
     let e = world.spawn((Pos { x: 1.0, y: 1.0 }, Vel { dx: 10.0, dy: 10.0 }));
@@ -137,6 +152,52 @@ fn query2_mut_same_type_panics() {
 }
 
 #[test]
+fn query3_wrapper_yields_entities_with_all_three() {
+    let mut world = World::new();
+    world.spawn((
+        Pos { x: 1.0, y: 0.0 },
+        Vel { dx: 2.0, dy: 0.0 },
+        Health(100),
+    ));
+    world.spawn((Pos { x: 3.0, y: 0.0 }, Vel { dx: 4.0, dy: 0.0 }));
+    world.spawn((Health(50),));
+
+    let results: Vec<_> = world.query3::<Pos, Vel, Health>().collect();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1.0.x, 1.0);
+    assert_eq!(results[0].1.1.dx, 2.0);
+    assert_eq!(results[0].1.2.0, 100);
+}
+
+#[test]
+fn query3_mut_wrapper_mutates_all_three() {
+    let mut world = World::new();
+    let e = world.spawn((
+        Pos { x: 1.0, y: 0.0 },
+        Vel { dx: 2.0, dy: 0.0 },
+        Health(100),
+    ));
+
+    for (_, (pos, vel, hp)) in world.query3_mut::<Pos, Vel, Health>() {
+        pos.x += 10.0;
+        vel.dx += 20.0;
+        hp.0 -= 50;
+    }
+
+    assert_eq!(world.get::<Pos>(e).unwrap().x, 11.0);
+    assert_eq!(world.get::<Vel>(e).unwrap().dx, 22.0);
+    assert_eq!(world.get::<Health>(e).unwrap().0, 50);
+}
+
+#[test]
+#[should_panic(expected = "cannot borrow the same column mutably twice")]
+fn query3_mut_duplicate_type_panics() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 0.0, y: 0.0 },));
+    let _ = world.query3_mut::<Pos, Vel, Pos>();
+}
+
+#[test]
 fn query_filtered_with_and_without() {
     let mut world = World::new();
     let e = world.spawn((Pos { x: 1.0, y: 0.0 }, Vel { dx: 2.0, dy: 0.0 }));
@@ -149,6 +210,33 @@ fn query_filtered_with_and_without() {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0, e);
+}
+
+#[test]
+fn query_iter_size_hint_tracks_remaining_rows() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    world.spawn((Pos { x: 2.0, y: 0.0 },));
+    world.spawn((Pos { x: 3.0, y: 0.0 },));
+
+    let mut iter = world.query::<&Pos>();
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    let _ = iter.next();
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+    let _ = iter.next();
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+}
+
+#[test]
+fn query_mut_size_hint_tracks_remaining_rows() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 }, Vel { dx: 1.0, dy: 0.0 }));
+    world.spawn((Pos { x: 2.0, y: 0.0 }, Vel { dx: 2.0, dy: 0.0 }));
+
+    let mut iter = world.query2_mut::<Pos, Vel>();
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+    let _ = iter.next();
+    assert_eq!(iter.size_hint(), (1, Some(1)));
 }
 
 #[test]

--- a/docs/guide/ecs.md
+++ b/docs/guide/ecs.md
@@ -77,6 +77,9 @@ for (entity, (pos, vel)) in world.query::<(&Position, &Velocity)>() {
 }
 ```
 
+If you prefer the old fixed-arity helpers, `query2`, `query2_mut`, `query3`, and
+`query3_mut` are available as thin wrappers over the typed query-spec API.
+
 > Queries return lazy iterators — call `.collect::<Vec<_>>()` if you need `len()` or indexing.
 
 Query with filters:


### PR DESCRIPTION
## Summary

- restore lazy-iterator parity polish on top of the new typed query system from #29
- add exact `size_hint` / `ExactSizeIterator` behavior for archetype query iterators
- add `query2`, `query2_mut`, `query3`, and `query3_mut` convenience wrappers plus regression coverage for the old PR #24 surface

Addresses #32 (completes iterator parity + tests)

## Journey Timeline

### Initial Plan

Start by comparing the old PR #24 iterator branch with the new typed archetype query layer from #29, then implement only the missing behavior on a stacked branch instead of rebuilding duplicate iterator machinery.

### What We Discovered

- #29 already absorbed the zero-allocation archetype iterator core, so #32 no longer needed a second iterator architecture
- the remaining gap was parity polish: wrapper methods for fixed-arity multi-component queries, exact `size_hint`, and old iterator-behavior regression coverage
- duplicate-type panics for `query3_mut` needed to happen eagerly in the wrapper, otherwise they could be skipped when no matching archetype existed

### Changes Made

- add exact `size_hint` + `ExactSizeIterator` for `QueryIter` and `QueryIterMut`
- add public aliases `Query2Iter`, `Query2MutIter`, `Query3Iter`, and `Query3MutIter`
- add `World::query2`, `query2_mut`, `query3`, and `query3_mut` as thin wrappers over the typed query-spec API
- extend `crates/engine/tests/query_iter.rs` with wrapper parity, three-component, duplicate-panic, and size-hint tests
- document the wrapper availability in the ECS guide and changelog

## Testing

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync`

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log -- PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
