### PR TITLE
fix(#60): restore rustfmt after PR #59

### DIFF
--- a/crates/engine/src/archetype.rs
+++ b/crates/engine/src/archetype.rs
@@ -578,8 +578,7 @@ impl ArchetypeStore {
         index: usize,
     ) -> Option<&'w mut Archetype> {
         unsafe {
-            let vec_ptr: *mut Vec<Archetype> =
-                std::ptr::addr_of_mut!((*this).archetypes);
+            let vec_ptr: *mut Vec<Archetype> = std::ptr::addr_of_mut!((*this).archetypes);
             (&mut *vec_ptr).get_mut(index)
         }
     }

--- a/crates/engine/src/system_param.rs
+++ b/crates/engine/src/system_param.rs
@@ -195,9 +195,7 @@ unsafe impl<T: Component> SystemParam for Query<'_, T> {
 
     unsafe fn fetch<'w>(world: UnsafeWorldCell) -> Query<'w, T> {
         Query {
-            results: unsafe {
-                QueryIter::<'w, &T>::new(world.archetypes()).collect()
-            },
+            results: unsafe { QueryIter::<'w, &T>::new(world.archetypes()).collect() },
         }
     }
 }
@@ -244,8 +242,7 @@ unsafe impl<T: Component> SystemParam for QueryMut<'_, T> {
     unsafe fn fetch<'w>(world: UnsafeWorldCell) -> QueryMut<'w, T> {
         QueryMut {
             results: unsafe {
-                QueryIterMut::<'w, &mut T>::new_from_ptr(world.archetypes_mut_ptr())
-                    .collect()
+                QueryIterMut::<'w, &mut T>::new_from_ptr(world.archetypes_mut_ptr()).collect()
             },
         }
     }

--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -141,8 +141,7 @@ impl UnsafeWorldCell {
         // is shared — combined with get_unchecked (which also uses &self),
         // no &mut Resources is ever created on this path.
         unsafe {
-            let resources_ptr: *const Resources =
-                std::ptr::addr_of!((*self.0).resources);
+            let resources_ptr: *const Resources = std::ptr::addr_of!((*self.0).resources);
             (*resources_ptr).get_unchecked::<T>()
         }
     }
@@ -166,8 +165,7 @@ impl UnsafeWorldCell {
         // only &Resources (shared). get_mut_unchecked uses UnsafeCell for
         // interior mutability — caller guarantees exclusive resource access.
         unsafe {
-            let resources_ptr: *const Resources =
-                std::ptr::addr_of!((*self.0).resources);
+            let resources_ptr: *const Resources = std::ptr::addr_of!((*self.0).resources);
             (*resources_ptr).get_mut_unchecked::<T>()
         }
     }
@@ -182,8 +180,7 @@ impl UnsafeWorldCell {
     pub unsafe fn archetypes<'w>(self) -> &'w ArchetypeStore {
         // SAFETY: Caller guarantees no mutable archetype access exists.
         unsafe {
-            let ptr: *const ArchetypeStore =
-                std::ptr::addr_of!((*self.0).archetypes);
+            let ptr: *const ArchetypeStore = std::ptr::addr_of!((*self.0).archetypes);
             &*ptr
         }
     }


### PR DESCRIPTION
<!-- shiplog:
kind: state
issue: 60
branch: issue/60-rust-fmt-after-pr59
status: resolved
updated_at: 2026-03-24T18:36:28.1131507Z
-->

## Summary

Restores Rust formatting on top of merged `master` after PR #59 left the Rust GitHub Actions job red on `cargo fmt --check`.

Closes #60

## Journey Timeline

- Post-merge CI inspection showed the failing Rust check was formatter drift, not a logic or test regression.
- Applied `cargo fmt` and kept the follow-up strictly formatting-only.

## Changes

- `crates/engine/src/archetype.rs` - rustfmt cleanup only
- `crates/engine/src/system_param.rs` - rustfmt cleanup only
- `crates/engine/src/world.rs` - rustfmt cleanup only

## Testing / Verification

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`

## Knowledge for Future Reference

The failing Rust workflow on PR #59 was caused by formatting drift in the UnsafeWorldCell follow-up changes, not by a behavioral regression. This PR exists only to restore CI to green on `master`.

Authored-by: openai/gpt-5.4 (codex, effort: high)
