### PR TITLE
feat(#56): add_legacy_system convenience wrapper

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -82,6 +82,25 @@ impl Engine {
         self
     }
 
+    /// Add a legacy `fn(&mut World)` system without requiring turbofish or cast.
+    ///
+    /// Convenience wrapper — equivalent to:
+    /// ```ignore
+    /// engine.add_system::<()>("stage", "name", my_fn as fn(&mut World));
+    /// ```
+    ///
+    /// Delegates to [`Schedule::add_legacy_system`]. Returns `&mut Self` for
+    /// chaining.
+    pub fn add_legacy_system(
+        &mut self,
+        stage: &'static str,
+        name: &'static str,
+        func: fn(&mut World),
+    ) -> &mut Self {
+        self.schedule.add_legacy_system(stage, name, func);
+        self
+    }
+
     /// Apply a plugin to this engine.
     ///
     /// Calls [`Plugin::build`] with `self`. Returns `&mut Self` for chaining.
@@ -429,5 +448,31 @@ mod tests {
 
         engine.pause();
         assert!(engine.world().try_resource::<VirtualTime>().is_some());
+    }
+
+    // -- add_legacy_system convenience wrapper (#56) --
+
+    #[test]
+    fn add_legacy_system_registers_and_runs() {
+        let mut engine = Engine::new();
+        engine.world_mut().spawn((Counter(0),));
+        engine.add_legacy_system("update", "increment", increment);
+        engine.run_once();
+
+        let counts: Vec<u32> = engine
+            .world()
+            .query::<&Counter>()
+            .map(|(_, c)| c.0)
+            .collect();
+        assert_eq!(counts, vec![1]);
+    }
+
+    #[test]
+    fn add_legacy_system_is_chainable() {
+        let mut engine = Engine::new();
+        engine
+            .add_legacy_system("pre", "increment", increment)
+            .add_legacy_system("post", "increment2", increment);
+        assert_eq!(engine.schedule().system_count(), 2);
     }
 }

--- a/crates/engine/src/schedule.rs
+++ b/crates/engine/src/schedule.rs
@@ -49,6 +49,22 @@ impl Schedule {
         self
     }
 
+    /// Add a legacy `fn(&mut World)` system without requiring turbofish or cast.
+    ///
+    /// This is a convenience wrapper for the common case where a system takes
+    /// `&mut World` directly. Equivalent to:
+    /// ```ignore
+    /// schedule.add_system::<()>("stage", "name", my_fn as fn(&mut World));
+    /// ```
+    pub fn add_legacy_system(
+        &mut self,
+        stage: &'static str,
+        name: &'static str,
+        func: fn(&mut World),
+    ) -> &mut Self {
+        self.add_system::<()>(stage, name, func)
+    }
+
     /// Run all systems in stage order.
     pub fn run(&mut self, world: &mut World) {
         for stage_idx in 0..self.stage_order.len() {
@@ -229,5 +245,30 @@ mod tests {
         schedule.run(&mut world);
 
         assert!((world.resource::<Speed>().0 - 2.0).abs() < f32::EPSILON);
+    }
+
+    // -- add_legacy_system convenience wrapper (#56) --
+
+    #[test]
+    fn add_legacy_system_registers_and_runs() {
+        let mut world = World::new();
+        world.spawn((Counter(0),));
+
+        let mut schedule = Schedule::new();
+        schedule.add_legacy_system("update", "increment", increment_system);
+
+        schedule.run(&mut world);
+
+        let val: Vec<u32> = world.query::<&Counter>().map(|(_, c)| c.0).collect();
+        assert_eq!(val, vec![1]);
+    }
+
+    #[test]
+    fn add_legacy_system_is_chainable() {
+        let mut schedule = Schedule::new();
+        schedule
+            .add_legacy_system("pre", "increment", increment_system)
+            .add_legacy_system("post", "double", double_system);
+        assert_eq!(schedule.system_count(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Closes #56

Adds `add_legacy_system` convenience methods to both `Schedule` and `Engine` that accept `fn(&mut World)` directly, eliminating the turbofish + cast ergonomics issue:

```rust
// Before (verbose):
engine.add_system::<()>("update", "my_system", my_system as fn(&mut World));

// After (clean):
engine.add_legacy_system("update", "my_system", my_system);
```

Both are thin wrappers that delegate to `add_system::<()>` internally.

## Test plan

- [x] `cargo test -p galeon-engine -- schedule::tests engine::tests` — all 27 pass
- [x] No API breaking changes — `add_system` remains unchanged, this is purely additive

---

Authored-by: claude/opus-4.6 (claude-code)
