### PR TITLE
feat(#30): Commands API for deferred structural mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Commands API for deferred structural mutations** — `Commands` system parameter buffers
+  spawn/despawn/insert/remove operations. Applied automatically between schedule stages via
+  `World::apply_commands()`. Avoids mid-iteration archetype changes and enables batching.
+  ([#30](https://github.com/galeon-engine/galeon/issues/30))
+
 ### Removed
 
 - **BREAKING: Legacy `fn(&mut World)` system path removed** — `LegacySystem`, `LegacySystemFn`,

--- a/crates/engine/src/commands.rs
+++ b/crates/engine/src/commands.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+use std::any::TypeId;
+
+use crate::component::Component;
+use crate::entity::Entity;
+use crate::system_param::Access;
+use crate::world::{Bundle, UnsafeWorldCell, World};
+
+/// A boxed, type-erased command closure.
+type BoxedCommand = Box<dyn FnOnce(&mut World)>;
+
+// =============================================================================
+// CommandBuffer — internal queue of deferred world mutations
+// =============================================================================
+
+/// A buffer of deferred structural mutations applied between schedule stages.
+///
+/// Commands are not the hot iteration path, so boxing each command is
+/// acceptable. The buffer is drained by [`World::apply_commands`].
+pub struct CommandBuffer {
+    queue: Vec<BoxedCommand>,
+}
+
+impl CommandBuffer {
+    pub fn new() -> Self {
+        Self { queue: Vec::new() }
+    }
+
+    /// Push a type-erased command onto the buffer.
+    fn push(&mut self, cmd: impl FnOnce(&mut World) + 'static) {
+        self.queue.push(Box::new(cmd));
+    }
+
+    /// Returns the number of queued commands.
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Returns `true` if no commands are queued.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Take all queued commands out, leaving the buffer empty.
+    ///
+    /// Used by [`World::apply_commands`] to drain the queue without
+    /// holding a borrow on the buffer while executing commands.
+    pub(crate) fn take(&mut self) -> Vec<BoxedCommand> {
+        std::mem::take(&mut self.queue)
+    }
+}
+
+impl Default for CommandBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Commands — typed system parameter for deferred mutations
+// =============================================================================
+
+/// System parameter that queues structural mutations for deferred application.
+///
+/// `Commands` buffers spawn, despawn, insert, and remove operations. These
+/// are applied between schedule stages via [`World::apply_commands`], avoiding
+/// mid-iteration archetype changes.
+///
+/// ```rust,ignore
+/// fn spawn_units(mut cmds: Commands<'_>) {
+///     cmds.spawn((Position { x: 0.0, y: 0.0 },));
+///     cmds.despawn(old_entity);
+///     cmds.insert(entity, Health(100));
+///     cmds.remove::<Velocity>(entity);
+/// }
+/// ```
+pub struct Commands<'w> {
+    buffer: &'w mut CommandBuffer,
+}
+
+impl<'w> Commands<'w> {
+    /// Spawn an entity with the given component bundle (deferred).
+    pub fn spawn<B: Bundle + Send + 'static>(&mut self, bundle: B) {
+        self.buffer.push(move |world: &mut World| {
+            world.spawn(bundle);
+        });
+    }
+
+    /// Despawn an entity (deferred).
+    pub fn despawn(&mut self, entity: Entity) {
+        self.buffer.push(move |world: &mut World| {
+            world.despawn(entity);
+        });
+    }
+
+    /// Insert a component into an entity (deferred).
+    ///
+    /// If the entity already has this component type, the value is overwritten.
+    pub fn insert<C: Component>(&mut self, entity: Entity, component: C) {
+        self.buffer.push(move |world: &mut World| {
+            world.insert(entity, component);
+        });
+    }
+
+    /// Remove a component from an entity (deferred).
+    pub fn remove<C: Component>(&mut self, entity: Entity) {
+        self.buffer.push(move |world: &mut World| {
+            world.remove::<C>(entity);
+        });
+    }
+
+    /// Returns the number of queued commands.
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Returns `true` if no commands are queued.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+}
+
+// =============================================================================
+// SystemParam implementation
+// =============================================================================
+
+// SAFETY: access() reports a unique marker type. fetch() only touches the
+// command buffer field, which no other SystemParam accesses. The buffer is
+// a separate field from resources and archetypes.
+unsafe impl crate::system_param::SystemParam for Commands<'_> {
+    type Item<'w> = Commands<'w>;
+
+    fn access() -> Vec<Access> {
+        // Use the CommandBuffer TypeId as a marker. This prevents two Commands
+        // params in the same system (which would alias) while not conflicting
+        // with any Res/ResMut/Query/QueryMut.
+        vec![Access::ResWrite(TypeId::of::<CommandBuffer>())]
+    }
+
+    unsafe fn fetch<'w>(world: UnsafeWorldCell) -> Commands<'w> {
+        Commands {
+            buffer: unsafe { world.commands_mut() },
+        }
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Component;
+    use crate::system_param::SystemParam;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Pos {
+        x: f32,
+        y: f32,
+    }
+    impl Component for Pos {}
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Vel {
+        x: f32,
+        y: f32,
+    }
+    impl Component for Vel {}
+
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, PartialEq)]
+    struct Health(i32);
+    impl Component for Health {}
+
+    // -- CommandBuffer --
+
+    #[test]
+    fn command_buffer_starts_empty() {
+        let buf = CommandBuffer::new();
+        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn command_buffer_tracks_length() {
+        let mut buf = CommandBuffer::new();
+        buf.push(|_| {});
+        buf.push(|_| {});
+        assert_eq!(buf.len(), 2);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn command_buffer_take_drains_all() {
+        let mut buf = CommandBuffer::new();
+        buf.push(|world: &mut World| {
+            world.spawn((Pos { x: 1.0, y: 2.0 },));
+        });
+        buf.push(|world: &mut World| {
+            world.spawn((Pos { x: 3.0, y: 4.0 },));
+        });
+
+        let mut world = World::new();
+        let commands = buf.take();
+        assert!(buf.is_empty());
+        for cmd in commands {
+            cmd(&mut world);
+        }
+        assert_eq!(world.entity_count(), 2);
+    }
+
+    // -- Commands typed API --
+
+    #[test]
+    fn commands_spawn_deferred() {
+        let mut world = World::new();
+        assert_eq!(world.entity_count(), 0);
+
+        // Queue a spawn via Commands.
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.spawn((Pos { x: 1.0, y: 2.0 },));
+        }
+
+        // Not spawned yet.
+        assert_eq!(world.entity_count(), 0);
+
+        // Apply commands.
+        world.apply_commands();
+        assert_eq!(world.entity_count(), 1);
+
+        let xs: Vec<f32> = world.query::<&Pos>().map(|(_, p)| p.x).collect();
+        assert_eq!(xs, vec![1.0]);
+    }
+
+    #[test]
+    fn commands_despawn_deferred() {
+        let mut world = World::new();
+        let e = world.spawn((Pos { x: 1.0, y: 2.0 },));
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.despawn(e);
+        }
+
+        // Still alive until apply.
+        assert!(world.is_alive(e));
+
+        world.apply_commands();
+        assert!(!world.is_alive(e));
+    }
+
+    #[test]
+    fn commands_insert_deferred() {
+        let mut world = World::new();
+        let e = world.spawn((Pos { x: 1.0, y: 2.0 },));
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.insert(e, Vel { x: 3.0, y: 4.0 });
+        }
+
+        // Vel not yet present.
+        assert!(world.get::<Vel>(e).is_none());
+
+        world.apply_commands();
+        assert_eq!(world.get::<Vel>(e).unwrap().x, 3.0);
+        // Pos preserved.
+        assert_eq!(world.get::<Pos>(e).unwrap().x, 1.0);
+    }
+
+    #[test]
+    fn commands_remove_deferred() {
+        let mut world = World::new();
+        let e = world.spawn((Pos { x: 1.0, y: 2.0 }, Vel { x: 3.0, y: 4.0 }));
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.remove::<Vel>(e);
+        }
+
+        // Vel still present until apply.
+        assert!(world.get::<Vel>(e).is_some());
+
+        world.apply_commands();
+        assert!(world.get::<Vel>(e).is_none());
+        assert_eq!(world.get::<Pos>(e).unwrap().x, 1.0);
+    }
+
+    #[test]
+    fn commands_multiple_ops_applied_in_order() {
+        let mut world = World::new();
+        let e = world.spawn((Pos { x: 1.0, y: 2.0 },));
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            // Insert then remove — net effect is no Vel.
+            cmds.insert(e, Vel { x: 10.0, y: 20.0 });
+            cmds.remove::<Vel>(e);
+        }
+
+        world.apply_commands();
+        assert!(world.get::<Vel>(e).is_none());
+    }
+
+    #[test]
+    fn commands_on_dead_entity_is_safe() {
+        let mut world = World::new();
+        let e = world.spawn((Pos { x: 1.0, y: 2.0 },));
+        world.despawn(e);
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.insert(e, Vel { x: 1.0, y: 1.0 });
+            cmds.despawn(e);
+            cmds.remove::<Pos>(e);
+        }
+
+        // Should not panic.
+        world.apply_commands();
+    }
+
+    #[test]
+    fn commands_spawn_multi_component() {
+        let mut world = World::new();
+
+        {
+            let buf = world.command_buffer_mut();
+            let mut cmds = Commands { buffer: buf };
+            cmds.spawn((Pos { x: 1.0, y: 2.0 }, Vel { x: 3.0, y: 4.0 }));
+        }
+
+        world.apply_commands();
+        assert_eq!(world.entity_count(), 1);
+
+        let results: Vec<_> = world.query::<(&Pos, &Vel)>().collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1.0.x, 1.0);
+        assert_eq!(results[0].1.1.x, 3.0);
+    }
+
+    // -- SystemParam integration --
+
+    #[test]
+    fn commands_access_uses_command_buffer_marker() {
+        let access = <Commands<'_> as SystemParam>::access();
+        assert_eq!(access.len(), 1);
+        assert_eq!(access[0], Access::ResWrite(TypeId::of::<CommandBuffer>()));
+    }
+
+    #[test]
+    fn commands_does_not_conflict_with_res() {
+        use crate::system_param::{Res, has_conflicts};
+        let a = <Commands<'_> as SystemParam>::access();
+        let b = <Res<'_, i32> as SystemParam>::access();
+        assert!(!has_conflicts(&a, &b));
+    }
+
+    #[test]
+    fn commands_does_not_conflict_with_query() {
+        use crate::system_param::{Query, has_conflicts};
+        let a = <Commands<'_> as SystemParam>::access();
+        let b = <Query<'_, Pos> as SystemParam>::access();
+        assert!(!has_conflicts(&a, &b));
+    }
+
+    #[test]
+    fn commands_fetch_via_unsafe_world_cell() {
+        let mut world = World::new();
+        let cell = unsafe { UnsafeWorldCell::new(&mut world as *mut World) };
+        unsafe {
+            let mut cmds: Commands<'_> = <Commands<'_> as SystemParam>::fetch(cell);
+            cmds.spawn((Pos { x: 42.0, y: 0.0 },));
+        }
+        world.apply_commands();
+        assert_eq!(world.entity_count(), 1);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate self as galeon_engine;
 
 pub mod archetype;
+pub mod commands;
 pub mod component;
 pub mod data;
 pub mod engine;
@@ -31,6 +32,7 @@ pub use inventory;
 pub use serde;
 
 // Re-exports for ergonomic API.
+pub use commands::Commands;
 pub use component::Component;
 pub use data::{DataRegistry, UnitStats, UnitTemplate};
 pub use engine::{Engine, Plugin};

--- a/crates/engine/src/schedule.rs
+++ b/crates/engine/src/schedule.rs
@@ -49,6 +49,9 @@ impl Schedule {
     }
 
     /// Run all systems in stage order.
+    ///
+    /// Queued commands are automatically applied between stages so that
+    /// deferred structural mutations from one stage are visible to the next.
     pub fn run(&mut self, world: &mut World) {
         for stage_idx in 0..self.stage_order.len() {
             let stage = self.stage_order[stage_idx];
@@ -57,6 +60,7 @@ impl Schedule {
                     entry.system.run(world);
                 }
             }
+            world.apply_commands();
         }
     }
 
@@ -225,5 +229,59 @@ mod tests {
         schedule.run(&mut world);
 
         assert!((world.resource::<Speed>().0 - 2.0).abs() < f32::EPSILON);
+    }
+
+    // -- Commands integration tests --
+
+    use crate::commands::Commands;
+
+    fn spawn_via_commands(mut cmds: Commands<'_>) {
+        cmds.spawn((Counter(100),));
+    }
+
+    #[test]
+    fn schedule_applies_commands_between_stages() {
+        let mut world = World::new();
+
+        // Stage "spawn" queues a deferred spawn.
+        // Stage "read" should see the spawned entity.
+        let mut schedule = Schedule::new();
+        schedule.add_system::<(Commands<'_>,)>("spawn", "spawner", spawn_via_commands);
+        schedule.add_system::<(QueryMut<'_, Counter>,)>("read", "increment", increment_system);
+
+        schedule.run(&mut world);
+
+        // Entity spawned by commands, then incremented: 100 + 1 = 101
+        let vals: Vec<u32> = world.query::<&Counter>().map(|(_, c)| c.0).collect();
+        assert_eq!(vals, vec![101]);
+    }
+
+    fn despawn_all_via_commands(
+        counters: crate::system_param::Query<'_, Counter>,
+        mut cmds: Commands<'_>,
+    ) {
+        for (entity, _) in counters.iter() {
+            cmds.despawn(entity);
+        }
+    }
+
+    #[test]
+    fn schedule_commands_despawn_visible_to_next_stage() {
+        let mut world = World::new();
+        world.spawn((Counter(1),));
+        world.spawn((Counter(2),));
+
+        let mut schedule = Schedule::new();
+        schedule.add_system::<(crate::system_param::Query<'_, Counter>, Commands<'_>)>(
+            "cleanup",
+            "despawn_all",
+            despawn_all_via_commands,
+        );
+        schedule.add_system::<(QueryMut<'_, Counter>,)>("post", "increment", increment_system);
+
+        schedule.run(&mut world);
+
+        // All entities despawned between stages — nothing to increment.
+        assert_eq!(world.entity_count(), 0);
     }
 }

--- a/crates/engine/src/world.rs
+++ b/crates/engine/src/world.rs
@@ -3,6 +3,7 @@
 use std::any::TypeId;
 
 use crate::archetype::{ArchetypeLayout, ArchetypeStore, EntityLocation};
+use crate::commands::CommandBuffer;
 use crate::component::Component;
 use crate::entity::{Entity, EntityMetaStore};
 use crate::query::{
@@ -204,17 +205,36 @@ impl UnsafeWorldCell {
         // any intermediate reference.
         unsafe { std::ptr::addr_of_mut!((*self.0).archetypes) }
     }
+
+    /// Get a mutable reference to the command buffer without creating
+    /// `&mut World`.
+    ///
+    /// # Safety
+    ///
+    /// - No other reference to the command buffer may exist concurrently.
+    /// - The command buffer is a separate field from resources and archetypes,
+    ///   so this does not alias other `UnsafeWorldCell` accessors.
+    #[inline]
+    pub unsafe fn commands_mut<'w>(self) -> &'w mut CommandBuffer {
+        // SAFETY: addr_of_mut! avoids creating &mut World. Caller guarantees
+        // exclusive access to the command buffer field.
+        unsafe {
+            let ptr: *mut CommandBuffer = std::ptr::addr_of_mut!((*self.0).commands);
+            &mut *ptr
+        }
+    }
 }
 
 // =============================================================================
 // World
 // =============================================================================
 
-/// The ECS world: owns entities, archetype storage, and resources.
+/// The ECS world: owns entities, archetype storage, resources, and commands.
 pub struct World {
     meta: EntityMetaStore,
     archetypes: ArchetypeStore,
     resources: Resources,
+    commands: CommandBuffer,
 }
 
 impl World {
@@ -227,6 +247,7 @@ impl World {
             meta: EntityMetaStore::new(),
             archetypes,
             resources: Resources::new(),
+            commands: CommandBuffer::new(),
         }
     }
 
@@ -315,6 +336,31 @@ impl World {
     /// Try to remove and return a resource. Returns `None` if not present.
     pub fn try_take_resource<T: 'static>(&mut self) -> Option<T> {
         self.resources.try_take::<T>()
+    }
+
+    // -------------------------------------------------------------------------
+    // Commands
+    // -------------------------------------------------------------------------
+
+    /// Drain and apply all queued commands.
+    ///
+    /// Called automatically between schedule stages. Can also be called
+    /// manually for setup code that uses deferred mutations.
+    pub fn apply_commands(&mut self) {
+        // Take the queue out to avoid borrowing self.commands while
+        // executing commands that need &mut World.
+        let commands = self.commands.take();
+        for cmd in commands {
+            cmd(self);
+        }
+    }
+
+    /// Get a mutable reference to the command buffer.
+    ///
+    /// This is the low-level escape hatch for tests and setup code. Systems
+    /// should use the [`Commands`](crate::commands::Commands) system parameter.
+    pub fn command_buffer_mut(&mut self) -> &mut CommandBuffer {
+        &mut self.commands
     }
 
     // -------------------------------------------------------------------------

--- a/docs/guide/ecs.md
+++ b/docs/guide/ecs.md
@@ -161,6 +161,43 @@ fn apply_gravity(gravity: Res<'_, Gravity>, mut velocities: QueryMut<'_, Velocit
 Conflict detection: if two parameters in the same system would alias (e.g.,
 `Res<T>` + `ResMut<T>`), the engine panics at registration time.
 
+### Deferred Mutations with Commands
+
+Ordinary systems should prefer deferred structural changes (spawn, despawn,
+insert, remove) via the `Commands` system parameter. These are buffered and
+applied between schedule stages, avoiding mid-iteration archetype changes.
+
+```rust
+use galeon_engine::Commands;
+
+fn spawn_reinforcements(mut cmds: Commands<'_>) {
+    cmds.spawn((Position { x: 0.0, y: 0.0 }, Health { current: 100, max: 100 },));
+}
+
+fn cleanup_dead(
+    units: Query<'_, Health>,
+    mut cmds: Commands<'_>,
+) {
+    for (entity, hp) in units.iter() {
+        if hp.current <= 0 {
+            cmds.despawn(entity);
+        }
+    }
+}
+```
+
+Available operations:
+
+| Method | Effect |
+|--------|--------|
+| `cmds.spawn(bundle)` | Deferred entity spawn |
+| `cmds.despawn(entity)` | Deferred entity despawn |
+| `cmds.insert(entity, component)` | Deferred component insert (archetype migration) |
+| `cmds.remove::<C>(entity)` | Deferred component removal (archetype migration) |
+
+Commands are applied automatically between schedule stages. You can also call
+`world.apply_commands()` manually in setup code.
+
 ## Schedule
 
 Systems are grouped into stages. Stages run in the order they're registered.
@@ -179,6 +216,9 @@ schedule.run(&mut world);
 
 The three-stage model (`input` → `simulate` → `sync`) ensures input is
 processed before simulation, and simulation completes before rendering sync.
+
+Queued commands are applied automatically between stages, so deferred
+structural mutations from one stage are visible to the next.
 
 ## Component Trait
 


### PR DESCRIPTION
## Summary

- Adds `CommandBuffer` + `Commands<'w>` system parameter for deferred spawn/despawn/insert/remove
- Commands applied automatically between schedule stages via `World::apply_commands()`
- `Commands` integrates with the `SystemParam` trait using `UnsafeWorldCell::commands_mut()`
- No conflicts with `Res`, `ResMut`, `Query`, `QueryMut` — uses `CommandBuffer` TypeId marker

## Files changed

| File | Change |
|------|--------|
| `commands.rs` (new) | `CommandBuffer` (type-erased queue) + `Commands<'w>` (typed API) + `SystemParam` impl |
| `world.rs` | `commands` field, `apply_commands()`, `command_buffer_mut()`, `UnsafeWorldCell::commands_mut()` |
| `schedule.rs` | Auto-apply commands between stages + 2 integration tests |
| `lib.rs` | Module + re-export |
| `docs/guide/ecs.md` | Commands section with usage table |
| `CHANGELOG.md` | Entry under Unreleased |

## Test plan

- [x] 11 unit tests in `commands::tests` (buffer lifecycle, typed API, SystemParam access, conflict detection)
- [x] 2 integration tests in `schedule::tests` (commands-between-stages spawn, commands-between-stages despawn)
- [x] All 178 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)