### PR TITLE
feat(#122): npm publishing surface for @galeon/* packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,7 @@ jobs:
 
       - run: bun install
       - run: bun run check
+      # Validate npm tarballs for publishable packages.
+      - run: npm pack --dry-run --workspace=packages/runtime
+      - run: npm pack --dry-run --workspace=packages/engine-ts
+      - run: npm pack --dry-run --workspace=packages/shell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# Publishes the three crates.io packages in dependency order.
+# Publishes Rust crates to crates.io and TS packages to npm.
 # Requires secret: CARGO_REGISTRY_TOKEN (crates.io API token).
+# npm uses trusted publishing (OIDC provenance) — no token needed after initial setup.
 
 name: Release
 
@@ -7,17 +8,27 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry-run galeon-engine-macros only (no upload)"
+        description: "Dry-run only (no upload)"
         required: true
         default: "false"
         type: choice
         options:
           - "true"
           - "false"
+      target:
+        description: "What to publish"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - "all"
+          - "crates"
+          - "npm"
 
 jobs:
-  publish:
+  publish-crates:
     name: Publish Rust crates
+    if: inputs.target == 'all' || inputs.target == 'crates'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,4 +52,41 @@ jobs:
             echo "Waiting for crates.io index (dependency for galeon-engine-three-sync)..."
             sleep 45
             cargo publish -p galeon-engine-three-sync
+          fi
+
+  publish-npm:
+    name: Publish npm packages
+    if: inputs.target == 'all' || inputs.target == 'npm'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install
+
+      - name: Build packages
+        run: bunx tsc --build
+
+      - name: Publish npm packages (ordered)
+        run: |
+          set -e
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm pack --dry-run --workspace=packages/runtime
+            npm pack --dry-run --workspace=packages/engine-ts
+            npm pack --dry-run --workspace=packages/shell
+          else
+            npm publish --workspace=packages/runtime --provenance --access public
+            npm publish --workspace=packages/engine-ts --provenance --access public
+            npm publish --workspace=packages/shell --provenance --access public
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **npm publishing surface** — `@galeon/runtime`, `@galeon/engine-ts`, and `@galeon/shell`
+  now emit JS + declarations to `dist/`, include proper `exports`/`types`/`main` fields,
+  and are publishable to npm. `workspace:*` replaced with exact version pins (`=0.1.0`).
+  CI validates `npm pack --dry-run` on every PR. Release workflow supports npm with
+  OIDC trusted publishing (provenance). Publishing guide updated for both registries.
+  ([#122](https://github.com/galeon-engine/galeon/issues/122))
 - **Crates.io publishing surface** — crate metadata (`description`, `keywords`, `categories`),
   `publish = false` on non-registry crates (`galeon-cli`, test crates), and pinned
   `version = "=0.1.0"` on path dependencies between publishable crates. CI dry-run

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -1,86 +1,115 @@
-# Publishing Galeon crates to crates.io
+# Publishing Galeon packages
 
-This repository publishes **three** Rust crates. Everything else in the workspace
-is internal (tests, CLI tooling, or deferred).
+Galeon publishes **three Rust crates** to crates.io and **three TypeScript
+packages** to npm. Everything else in the workspace is internal.
 
-## Publish surface
+## Publish surfaces
 
-| Crate | Package name on crates.io | Order |
-|-------|---------------------------|-------|
+### Rust crates (crates.io)
+
+| Crate | Package name | Order |
+|-------|-------------|-------|
 | Macros | `galeon-engine-macros` | 1 — publish first |
 | Core engine | `galeon-engine` | 2 — depends on macros |
 | Three.js sync | `galeon-engine-three-sync` | 3 — depends on engine |
 
-## Not published
+### TypeScript packages (npm)
+
+| Package | npm name | Order |
+|---------|----------|-------|
+| Runtime | `@galeon/runtime` | 1 — publish first |
+| Engine TS | `@galeon/engine-ts` | 2 — depends on runtime |
+| Shell | `@galeon/shell` | 3 — no deps, last by convention |
+
+### Not published
 
 - `galeon-cli` — `publish = false` (deferred)
 - `galeon-protocol-rename-test`, `galeon-protocol-consumer-test` — `publish = false` (integration tests)
 
-JavaScript packages under `packages/` are **not** published to npm until separate
-blockers are resolved (see project issues).
+## Versioning
 
-## Path dependencies and versions
+All Rust crates and all TypeScript packages move in **lockstep**. Internal
+dependencies use exact pins (`=0.1.0`) to enforce this.
 
-Workspace crates that ship to crates.io use **path + pinned version** on each
-other, for example:
+When bumping versions:
+1. Update `version` in all three `crates/*/Cargo.toml` and the workspace root.
+2. Update `version` in all three `packages/*/package.json`.
+3. Update dependency version pins between packages.
+
+## Path dependencies and versions (Rust)
+
+Workspace crates use **path + pinned version**:
 
 ```toml
 galeon-engine-macros = { path = "../engine-macros", version = "=0.1.0" }
 ```
 
-When you publish, Cargo strips `path` and keeps the version for consumers.
-Keep these versions aligned with the `[package] version` of the dependency.
+Cargo strips `path` for published tarballs.
 
 ## Local checks
 
-Cargo turns path dependencies into registry versions when it builds the publish
-tarball. Until a dependency already exists on crates.io at the pinned version,
-`cargo publish -p galeon-engine` and `cargo publish -p galeon-engine-three-sync`
-fail during packaging (even with `--no-verify`).
-
-**Always valid (CI runs this after tests):**
+### Rust
 
 ```bash
 cargo publish -p galeon-engine-macros --dry-run
 ```
 
-**After `galeon-engine-macros` is on crates.io at the pinned version:**
+`galeon-engine` and `galeon-engine-three-sync` dry-runs only pass after their
+dependencies exist on crates.io at the pinned version.
+
+### TypeScript
 
 ```bash
-cargo publish -p galeon-engine --dry-run --no-verify
+bunx tsc --build                           # Build JS + declarations
+npm pack --dry-run --workspace=packages/runtime
+npm pack --dry-run --workspace=packages/engine-ts
+npm pack --dry-run --workspace=packages/shell
 ```
-
-**After `galeon-engine` is on crates.io at the pinned version:**
-
-```bash
-cargo publish -p galeon-engine-three-sync --dry-run --no-verify
-```
-
-`--no-verify` skips the extracted-crate build step against the registry; you can
-drop it once you want the stricter check.
-
-After all three crates exist on crates.io for the current versions, you can run
-the three commands back-to-back for a full preflight.
 
 ## Release procedure
 
-1. Bump versions in all three `Cargo.toml` files (keep path-dep pins in sync).
-2. Commit and tag (for example `v0.1.1` if all three share the same release).
-3. Run the **Release** GitHub workflow (see `.github/workflows/release.yml`) or
-   publish manually:
+1. Bump versions in all `Cargo.toml` and `package.json` files (keep pins in sync).
+2. Commit and tag (e.g. `v0.2.0`).
+3. Run the **Release** GitHub workflow (`.github/workflows/release.yml`):
+   - Choose target: `all`, `crates`, or `npm`.
+   - Use `dry_run: true` first to validate.
+
+### Manual publish (first time or fallback)
+
+**Rust:**
 
 ```bash
 cargo publish -p galeon-engine-macros
-# wait until the crate is visible on crates.io
+# wait ~45s for crates.io index
 cargo publish -p galeon-engine
+# wait ~45s
 cargo publish -p galeon-engine-three-sync
 ```
 
-4. `galeon-engine-three-sync` needs the `wasm32-unknown-unknown` target for
-   packaging; ensure it is installed (`rustup target add wasm32-unknown-unknown`).
+**npm (first publish — after this, use trusted publishing via CI):**
+
+```bash
+npm login
+cd packages/runtime  && npm publish --access public && cd ../..
+cd packages/engine-ts && npm publish --access public && cd ../..
+cd packages/shell    && npm publish --access public && cd ../..
+```
+
+After the first publish, enable trusted publishing on npm for each package
+(link to the `galeon-engine/galeon` GitHub repo). Subsequent releases use
+OIDC provenance from GitHub Actions — no token needed.
 
 ## Authentication
 
-- **CI / GitHub Actions:** store a crates.io token in the repository secret
-  `CARGO_REGISTRY_TOKEN`.
+### crates.io
+
+- **CI:** `CARGO_REGISTRY_TOKEN` repository secret.
 - **Local:** `cargo login` or set `CARGO_REGISTRY_TOKEN` in the environment.
+
+### npm
+
+- **CI:** Trusted publishing via OIDC (`id-token: write` permission in workflow).
+  No `NPM_TOKEN` secret needed after initial setup.
+- **Local (first publish only):** `npm login` with your npm account.
+- **Scope:** The `@galeon` npm org owns the scope. Add team members via
+  `npm org set galeon <user> developer`.

--- a/packages/engine-ts/package.json
+++ b/packages/engine-ts/package.json
@@ -1,11 +1,29 @@
 {
   "name": "@galeon/engine-ts",
   "version": "0.1.0",
-  "private": true,
+  "description": "Galeon Engine TypeScript layer — Three.js sync consumer for WASM extraction snapshots",
   "type": "module",
-  "module": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "src"],
+  "keywords": ["galeon", "game-engine", "threejs", "wasm", "ecs"],
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galeon-engine/galeon.git",
+    "directory": "packages/engine-ts"
+  },
+  "scripts": {
+    "prepublishOnly": "tsc --build"
+  },
   "dependencies": {
-    "@galeon/runtime": "workspace:*",
+    "@galeon/runtime": "=0.1.0",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/engine-ts/tsconfig.json
+++ b/packages/engine-ts/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": false,
-    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,9 +1,27 @@
 {
   "name": "@galeon/runtime",
   "version": "0.1.0",
-  "private": true,
+  "description": "Galeon Engine runtime — thin JS↔WASM invoke/events bridge",
   "type": "module",
-  "module": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "src"],
+  "keywords": ["galeon", "game-engine", "wasm", "runtime"],
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galeon-engine/galeon.git",
+    "directory": "packages/runtime"
+  },
+  "scripts": {
+    "prepublishOnly": "tsc --build"
+  },
   "devDependencies": {
     "@types/bun": "latest"
   },

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": false,
-    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,9 +1,27 @@
 {
   "name": "@galeon/shell",
   "version": "0.1.0",
-  "private": true,
+  "description": "Galeon Engine editor shell — Godot-style Solid.js panel UI",
   "type": "module",
-  "module": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "src"],
+  "keywords": ["galeon", "game-engine", "editor", "shell"],
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galeon-engine/galeon.git",
+    "directory": "packages/shell"
+  },
+  "scripts": {
+    "prepublishOnly": "tsc --build"
+  },
   "devDependencies": {
     "@types/bun": "latest"
   },

--- a/packages/shell/tsconfig.json
+++ b/packages/shell/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": false,
-    "emitDeclarationOnly": true,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
     "rootDir": "src",
     "outDir": "dist",
     "jsx": "preserve"


### PR DESCRIPTION
## Summary

- **Build**: tsconfigs emit JS + declarations to `dist/` (was declaration-only)
- **Package.json**: proper `exports`/`types`/`main`/`files` fields, npm metadata, `private: true` removed
- **Deps**: `workspace:*` → `=0.1.0` exact pin on `@galeon/runtime`
- **CI**: `npm pack --dry-run` validates all 3 packages on every PR
- **Release**: workflow supports npm publish with OIDC trusted publishing (`--provenance`)
- **Docs**: publishing guide covers both crates.io and npm

## Dry-run results

| Package | `npm pack --dry-run` | Files |
|---------|---------------------|-------|
| `@galeon/runtime` | PASS | 5 (dist + src) |
| `@galeon/engine-ts` | PASS | 13 (dist + src) |
| `@galeon/shell` | PASS | 5 (dist + src) |

## First publish plan

1. Merge this PR
2. Manual `npm login` + `npm publish --access public` for each package (first publish)
3. Enable trusted publishing on npm for each package → link to GitHub repo
4. Future releases: use Release workflow with `target: npm`

## Test plan

- [x] `bunx tsc --build` — clean build produces JS + declarations
- [x] `bun run check` — existing type-check passes
- [x] `npm pack --dry-run` — all 3 packages produce correct tarballs
- [ ] CI passes (Rust + TypeScript jobs)
- [ ] After first publish, `npm install @galeon/engine-ts` resolves correctly

## Closes

Resolves #106, #107, #108
Parent: #122

Authored-by: claude/opus-4.6 (claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)