### PR TITLE
feat(#128): add version bump script for lockstep releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Version bump script** — `scripts/bump-version.sh X.Y.Z` updates all 6 lockstep
-  version sources (7 edits) atomically. Validates semver, checks current versions are
-  consistent, and verifies all edits after applying. Supports prerelease tags.
+- **Version bump script** — `bash scripts/bump-version.sh X.Y.Z` updates all 6
+  lockstep version sources (7 edits). Validates SemVer 2.0.0, checks current
+  versions are consistent, and rolls back if verification fails. Supports
+  prerelease and build metadata tags.
   ([#128](https://github.com/galeon-engine/galeon/issues/128))
 
 ### Changed

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -42,8 +42,9 @@ Run the bump script from the repo root:
 bash scripts/bump-version.sh A.B.C
 ```
 
-This updates all 6 files (7 edits) atomically after verifying the current
-versions are consistent. It supports prerelease tags (`0.2.0-alpha.1`).
+This updates all 6 files (7 edits) after verifying the current versions are
+consistent, and rolls back if verification fails. It supports prerelease and
+build metadata tags (`0.2.0-alpha.1`, `0.2.0-alpha-1+build-7`).
 
 The script edits these locations:
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 #
-# bump-version.sh — Update all 6 lockstep version sources atomically.
+# bump-version.sh — Update all 6 lockstep version sources with rollback on failure.
 #
 # Usage: scripts/bump-version.sh X.Y.Z
 #
@@ -13,9 +13,40 @@ set -euo pipefail
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
-die()    { printf 'error: %s\n' "$1" >&2; exit 1; }
-ok()     { printf '  ✓ %s\n' "$1"; }
+die()      { printf 'error: %s\n' "$1" >&2; exit 1; }
+ok()       { printf '  ✓ %s\n' "$1"; }
 strip_cr() { tr -d '\r'; }  # neutralise CRLF on Windows checkouts
+
+BACKUP_DIR=""
+ROLLBACK_NEEDED=0
+
+restore_backups() {
+  [[ $ROLLBACK_NEEDED -eq 1 ]] || return 0
+
+  for f in "${ALL_FILES[@]}"; do
+    [[ -f "$BACKUP_DIR/$f" ]] || continue
+    cp "$BACKUP_DIR/$f" "$f"
+  done
+
+  printf 'Rolled back partial changes.\n' >&2
+}
+
+cleanup() {
+  [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]] && rm -rf "$BACKUP_DIR"
+}
+
+on_exit() {
+  local status=$?
+
+  if [[ $status -ne 0 ]]; then
+    restore_backups
+  fi
+
+  cleanup
+  exit "$status"
+}
+
+trap on_exit EXIT
 
 # ── Args ─────────────────────────────────────────────────────────────
 
@@ -28,8 +59,8 @@ if [[ -z "$NEW_VERSION" ]]; then
   exit 1
 fi
 
-# Validate semver (with optional prerelease/build metadata)
-if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?(\+[a-zA-Z0-9._-]+)?$ ]]; then
+# Validate SemVer 2.0.0 (with optional prerelease/build metadata)
+if ! [[ "$NEW_VERSION" =~ ^(0|[1-9][0-9]*)\.((0|[1-9][0-9]*))\.((0|[1-9][0-9]*))(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
   die "Invalid semver: '$NEW_VERSION' (expected X.Y.Z[-prerelease][+build])"
 fi
 
@@ -141,6 +172,13 @@ echo "Bumping $CURRENT → $NEW_VERSION ..."
 OLD_ESC="${CURRENT//./\\.}"
 NEW_ESC="${NEW_VERSION//./\\.}"
 
+BACKUP_DIR="$(mktemp -d)"
+for f in "${ALL_FILES[@]}"; do
+  mkdir -p "$BACKUP_DIR/$(dirname "$f")"
+  cp "$f" "$BACKUP_DIR/$f"
+done
+ROLLBACK_NEEDED=1
+
 # 1. Workspace Cargo.toml
 sed -i "/\[workspace\.package\]/,/^\[/ s/version = \"$OLD_ESC\"/version = \"$NEW_VERSION\"/" "$WORKSPACE_CARGO"
 ok "$WORKSPACE_CARGO"
@@ -194,6 +232,8 @@ verify "$SHELL_PKG"          "\"version\": \"$NEW_VERSION\""         "shell vers
 if [[ $ERRORS -gt 0 ]]; then
   die "$ERRORS verification(s) failed. Check the files manually."
 fi
+
+ROLLBACK_NEEDED=0
 
 echo ""
 echo "Done. All 7 locations updated to $NEW_VERSION."


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 128
branch: issue/128-version-bump-script
status: resolved
updated_at: 2026-04-05T10:53:08.9651189Z
-->

## Summary

This PR adds a dedicated version bump script for Galeon's lockstep release surface and documents the release workflow around it. The script validates current version consistency across the Rust and TypeScript publish surfaces, updates all seven version pins, and now restores the original files if verification fails so a bad replacement does not leave the tree half-bumped.

Closes #128

## Journey Timeline

### Initial Plan
Implement the issue's proposed `scripts/bump-version.sh X.Y.Z` flow so version bumps stop relying on a seven-edit manual ceremony spread across Cargo and npm package metadata.

### What We Discovered
- Windows CRLF checkouts broke the first implementation because `sed` extraction of the workspace version preserved `\r`, making the consistency check fail before any bump could happen.
- Direct script invocation was not portable across checkouts until the executable bit and docs were aligned; the release guide now uses `bash scripts/bump-version.sh ...` while the file remains executable on POSIX.
- Review pressure exposed two extra correctness gaps after the initial hardening pass: failed verification could leave partial edits behind, and the widened regex accepted non-SemVer identifiers such as versions with underscores.

### Implementation Issues
- Review found that the script's original "atomic" claim was too strong. The final implementation now snapshots all six target files before editing and restores them on any non-zero exit, then the docs/changelog were updated to describe rollback-on-failure semantics instead of atomic multi-file writes.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Delivery surface | Shell script in `scripts/` | Lowest-friction way to automate the existing release ceremony without moving release ownership out of the repo docs/workflow. |
| Failure handling | Backup + rollback on error | Prevents partial version bumps when a replacement or verification step misses one target. |
| Version validation | Strict SemVer 2.0.0 regex | Accepts valid prerelease/build metadata while rejecting invalid identifiers that would otherwise be written into package metadata. |
| Release docs invocation | `bash scripts/bump-version.sh A.B.C` | Works cleanly across Windows, WSL, Git Bash, and POSIX checkouts. |

### Changes Made

**Commits:**
- `bee9576 fix(#128): enforce rollback and strict semver validation`
- `3cd2f85 fix(#128): handle CRLF, executable bit, and hyphenated prerelease`
- `dcf5c68 feat(#128): add version bump script to update all 6 lockstep sources`

## Testing

- [x] `bash -n scripts/bump-version.sh`
- [x] Disposable-copy run on the Windows CRLF checkout for `0.2.0-alpha-1+build-7`, verifying all 7 version locations update together.
- [x] Disposable-copy rejection of invalid `0.2.0-alpha_1`, confirming strict SemVer validation.
- [x] Disposable-copy forced verification miss, confirming the script restores the original files instead of leaving partial edits behind.
- [x] Self-audit: reviewed the script and docs for portability, rollback semantics, and consistency with the shiplog review findings.
- [ ] Repo-wide `cargo`/`bun` suites not run; the change is limited to release tooling and documentation.

**Verification summary:** Script parsing, CRLF handling, prerelease/build metadata support, invalid-version rejection, and rollback-on-failure behavior were validated directly. No engine/runtime code paths changed.

## Stacked PRs / Related

- None

## Knowledge for Future Reference

This script intentionally covers the current six lockstep version sources and seven edits called out in the publishing guide. If a future release surface adds another pinned package or crate dependency, update both the script and `docs/guide/publishing.md` together. Merge requires a cross-model review sign-off per the **shiplog** review gate.

---
Authored-by: openai/gpt-5.4 (codex, effort: xhigh)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
