### PR TITLE
ci(#101): create GitHub Releases from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@
 
 name: Release
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     tags: ['v*']
@@ -277,3 +280,56 @@ jobs:
           path: .release-evidence
           if-no-files-found: error
           include-hidden-files: true
+
+  github-release:
+    name: GitHub Release
+    needs: [publish-npm, publish-crates, verify-publish, release-evidence]
+    if: >-
+      github.event_name != 'workflow_dispatch' &&
+      !cancelled() &&
+      needs.publish-npm.result == 'success' &&
+      needs.publish-crates.result == 'success' &&
+      needs.verify-publish.result == 'success' &&
+      needs.release-evidence.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-evidence-${{ github.ref_name }}
+          path: .release-evidence
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          evidence=".release-evidence/release-evidence-v${version}.md"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub Release ${tag} already exists; refreshing attached evidence."
+            gh release upload "$tag" "${evidence}#Release Evidence" --clobber
+            if [[ "$version" == *-* ]]; then
+              gh release edit "$tag" --title "$tag" --prerelease
+            else
+              gh release edit "$tag" --title "$tag" --latest
+            fi
+            exit 0
+          fi
+
+          if [[ "$version" == *-* ]]; then
+            gh release create "$tag" "${evidence}#Release Evidence" \
+              --title "$tag" \
+              --generate-notes \
+              --verify-tag \
+              --prerelease \
+              --latest=false
+          else
+            gh release create "$tag" "${evidence}#Release Evidence" \
+              --title "$tag" \
+              --generate-notes \
+              --verify-tag \
+              --latest
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **GitHub Release automation** — tag-triggered releases now create/update a
+  GitHub Release after publish + verification succeed, attach the evidence
+  markdown as a release asset, and mark prerelease tags as prereleases.
+  Verify-only workflow dispatches continue to skip release creation.
+  ([#101](https://github.com/galeon-engine/galeon/issues/101))
 - **Tag-triggered release workflow** — `release.yml` now triggers on `v*` tag pushes
   instead of manual `workflow_dispatch`. CI runs as a gate via `workflow_call` before
   any publish step. Crates.io propagation uses `cargo search` polling (30 x 10s)

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -100,12 +100,14 @@ npm pack --dry-run --workspace=packages/shell
    - npm packages publish with skip-if-exists guards
    - Post-publish verification installs from registries
    - Evidence bundle uploaded as workflow artifact
+   - GitHub Release created from the pushed tag, with prerelease tags marked as prereleases and the evidence markdown attached as a release asset
 
 ### Verify-only (manual dispatch)
 
 Use `workflow_dispatch` with an explicit version input to re-verify an
 already-published version without re-publishing. Installs from registries
-and checks the artifacts work.
+and checks the artifacts work. Verify-only runs do **not** create or edit a
+GitHub Release.
 
 ### Manual publish (first time or fallback)
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "workspaces": ["packages/*"],
   "scripts": {
-    "check": "tsc --build",
-    "build": "tsc --build"
+    "check": "bunx tsc --build",
+    "build": "bunx tsc --build"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/tests/release-workflow-logic.sh
+++ b/tests/release-workflow-logic.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 #
 # Tests the shell logic used by .github/workflows/release.yml.
-# Pure logic only — no working-tree file reads.
+# Pure logic only - no working-tree file reads.
 #
 # Run from anywhere: bash tests/release-workflow-logic.sh
 
@@ -17,22 +17,22 @@ assert_eq() {
     echo "  PASS: $label"
     PASS=$((PASS + 1))
   else
-    echo "  FAIL: $label — expected '$expected', got '$actual'"
+    echo "  FAIL: $label - expected '$expected', got '$actual'"
     FAIL=$((FAIL + 1))
   fi
 }
 
-# ── Tag stripping (GITHUB_REF_NAME#v) ───────────────────────────────
+# -- Tag stripping (GITHUB_REF_NAME#v) --------------------------------
 
 echo "=== Tag version stripping ==="
 for CASE in "v0.2.0|0.2.0" "v1.0.0-alpha.1|1.0.0-alpha.1" "v0.3.0-rc.2|0.3.0-rc.2" "v10.20.30|10.20.30"; do
   INPUT="${CASE%%|*}"
   EXPECTED="${CASE##*|}"
   ACTUAL="${INPUT#v}"
-  assert_eq "$INPUT → $EXPECTED" "$EXPECTED" "$ACTUAL"
+  assert_eq "$INPUT -> $EXPECTED" "$EXPECTED" "$ACTUAL"
 done
 
-# ── Prerelease dist-tag (gametau pattern: prerelease → alpha) ────────
+# -- Prerelease dist-tag (gametau pattern: prerelease -> alpha) ------
 
 echo ""
 echo "=== Prerelease dist-tag ==="
@@ -40,10 +40,48 @@ for CASE in "0.2.0|latest" "1.0.0-alpha.1|alpha" "0.3.0-beta.2|alpha" "0.2.0-0.1
   VER="${CASE%%|*}"
   EXPECTED="${CASE##*|}"
   if [[ "$VER" == *-* ]]; then TAG="alpha"; else TAG="latest"; fi
-  assert_eq "$VER → $EXPECTED" "$EXPECTED" "$TAG"
+  assert_eq "$VER -> $EXPECTED" "$EXPECTED" "$TAG"
 done
 
-# ── cargo search propagation grep ────────────────────────────────────
+# -- GitHub Release metadata -----------------------------------------
+
+echo ""
+echo "=== GitHub Release flags ==="
+for CASE in "0.2.0|false|--latest" "1.0.0-alpha.1|true|--latest=false" "0.3.0-rc.2|true|--latest=false"; do
+  VER="${CASE%%|*}"
+  REST="${CASE#*|}"
+  EXPECTED_PRERELEASE="${REST%%|*}"
+  EXPECTED_LATEST="${REST##*|}"
+
+  if [[ "$VER" == *-* ]]; then
+    PRERELEASE="true"
+    LATEST_FLAG="--latest=false"
+  else
+    PRERELEASE="false"
+    LATEST_FLAG="--latest"
+  fi
+
+  assert_eq "$VER prerelease" "$EXPECTED_PRERELEASE" "$PRERELEASE"
+  assert_eq "$VER latest flag" "$EXPECTED_LATEST" "$LATEST_FLAG"
+done
+
+echo ""
+echo "=== Release evidence artifact naming ==="
+for CASE in "v0.2.0|release-evidence-v0.2.0|.release-evidence/release-evidence-v0.2.0.md" \
+            "v1.0.0-alpha.1|release-evidence-v1.0.0-alpha.1|.release-evidence/release-evidence-v1.0.0-alpha.1.md"; do
+  TAG="${CASE%%|*}"
+  REST="${CASE#*|}"
+  EXPECTED_ARTIFACT="${REST%%|*}"
+  EXPECTED_FILE="${REST##*|}"
+
+  ACTUAL_ARTIFACT="release-evidence-${TAG}"
+  ACTUAL_FILE=".release-evidence/release-evidence-v${TAG#v}.md"
+
+  assert_eq "$TAG artifact name" "$EXPECTED_ARTIFACT" "$ACTUAL_ARTIFACT"
+  assert_eq "$TAG evidence file" "$EXPECTED_FILE" "$ACTUAL_FILE"
+done
+
+# -- cargo search propagation grep ------------------------------------
 
 echo ""
 echo "=== cargo search grep pattern ==="
@@ -55,7 +93,7 @@ assert_eq "matches published 0.1.0" "true" "$FOUND"
 FOUND="$( echo "$SEARCH_OUTPUT" | grep -q '"0.2.0"' && echo true || echo false )"
 assert_eq "rejects missing 0.2.0" "false" "$FOUND"
 
-# ── "already exists" string match ────────────────────────────────────
+# -- "already exists" string match ------------------------------------
 
 echo ""
 echo "=== already-exists detection ==="
@@ -67,7 +105,7 @@ OUTPUT='error: failed to select a version for the requirement `galeon-engine-mac
 MATCH="$( [[ "$OUTPUT" == *"already exists on crates.io index"* ]] && echo true || echo false )"
 assert_eq "rejects propagation error" "false" "$MATCH"
 
-# ── Propagation retry detection ──────────────────────────────────────
+# -- Propagation retry detection --------------------------------------
 
 echo ""
 echo "=== propagation retry detection ==="
@@ -85,7 +123,7 @@ if [[ "$OUTPUT" == *"failed to select a version"* ]] && [[ "$OUTPUT" == *"galeon
 fi
 assert_eq "does not retry on unrelated error" "false" "$RETRY"
 
-# ── awk version extraction ───────────────────────────────────────────
+# -- awk version extraction -------------------------------------------
 
 echo ""
 echo "=== awk version extraction ==="
@@ -93,10 +131,10 @@ TOML_LINE='version = "0.2.0"'
 EXTRACTED="$(echo "$TOML_LINE" | awk -F'"' '/^version = / {print $2; exit}')"
 assert_eq "extracts 0.2.0 from TOML line" "0.2.0" "$EXTRACTED"
 
-# ── Results ──────────────────────────────────────────────────────────
+# -- Results ----------------------------------------------------------
 
 echo ""
-echo "════════════════════════════════"
+echo "================================"
 echo "Results: $PASS passed, $FAIL failed"
-echo "════════════════════════════════"
+echo "================================"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 101
branch: issue/101-github-release-pipeline
status: in-progress
updated_at: 2026-04-05T11:05:09.8182103Z
-->

## Summary

This PR extends Galeon's release pipeline so successful tag-driven releases also create or refresh a GitHub Release, attach the release evidence markdown as an asset, and flag prerelease tags correctly. It also fixes the local release verification path on the Windows worktree by making the shell logic test runnable under Bash and by aligning the root TypeScript scripts with the `bunx tsc --build` invocation the workflow already uses.

Addresses #101 (completes T4)

## Completed Tasks

- [x] **T4:** Add release workflow and checklist - the release pipeline now includes GitHub Release creation after publish + verification, and the publishing guide documents the new behavior and verify-only limits.

## Remaining Tasks

- [ ] **T1:** Define release units and package set - still open in the parent issue.
- [ ] **T2:** Define versioning policy - still open in the parent issue.
- [ ] **T3:** Make install paths consume published prereleases - still open in the parent issue.
- [ ] **T5:** Document stability expectations for consumers - still open in the parent issue.

## Blocked On

- Actual tag-push publish-path verification is intentionally deferred until a maintainer chooses a real release/prerelease version to publish. Triggering that path would create a real public tag/release and may publish to crates.io/npm if the version is new.

## Journey Timeline

### Initial Plan
Close the gap between registry publishing and GitHub's own release surface so tag-driven releases leave behind a canonical GitHub Release artifact, then verify the workflow and local test path end-to-end without triggering an accidental public publish.

### What We Discovered
- The current `Release` workflow already publishes to crates.io/npm and emits an evidence artifact, but it does not create a GitHub Release object at all.
- Published artifacts already exist for `0.1.0` on crates.io and npm, and the current verify-only `Release` workflow on `master` succeeds for `version=0.1.0` while leaving GitHub Releases empty.
- Baseline release verification on the Windows worktree exposed two testability gaps: `tests/release-workflow-logic.sh` was checked out with CRLF so Bash aborted immediately, and `bun run check` / `bun run build` failed because the root scripts used bare `tsc` instead of `bunx tsc`.

### Implementation Issues
- The GitHub Release job needed to be rerun-safe, not just create-once. The final job refreshes the attached evidence asset when the release already exists instead of failing on reruns.
- Verify-only workflow dispatches should stay side-effect free. The final workflow keeps the new `GitHub Release` job present but skipped on `workflow_dispatch`, which was validated in a branch run.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Release artifact strategy | Create/update GitHub Releases only on tag pushes | Keeps `workflow_dispatch` safe for verification while making real releases visible in GitHub. |
| Release evidence handling | Attach the generated evidence markdown as a release asset | Preserves the existing evidence bundle and makes the audit trail discoverable from the GitHub Release page. |
| Prerelease handling | Mark hyphenated versions as prereleases and `--latest=false` | Matches the existing prerelease dist-tag logic and avoids prerelease tags claiming Latest. |
| Local TS verification | Use `bunx tsc --build` in root scripts | Makes the documented local check/build entrypoints actually runnable on this Windows/Bun setup. |

### Changes Made

**Commits:**
- `419a05d feat(#101/T4): create GitHub Releases from tags`

## Testing

- [x] Baseline registry check: confirmed `0.1.0` exists on crates.io for `galeon-engine-macros`, `galeon-engine`, and `galeon-engine-three-sync`, and on npm for `@galeon/runtime`, `@galeon/engine-ts`, and `@galeon/shell`.
- [x] Baseline GitHub check: confirmed `gh release list` is empty before this change.
- [x] Baseline workflow check: `Release` workflow_dispatch on `master` with `version=0.1.0` succeeded (`24000077950`) and produced `release-evidence-v0.1.0` without creating a GitHub Release.
- [x] `bash tests/release-workflow-logic.sh`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync`
- [x] `bun install`
- [x] `bun run check`
- [x] `bun run build`
- [x] Branch workflow check: `Release` workflow_dispatch on `issue/101-github-release-pipeline` with `version=0.1.0` succeeded (`24000170803`), produced the evidence artifact, and showed the new `GitHub Release` job skipped as intended on verify-only runs.
- [ ] Real tag-push publish path not executed in this PR because it would create a public tag/release and may publish registries for a new version.

**Verification summary:** The updated workflow is accepted by GitHub Actions, the verify-only path remains green, the local release validation commands now work on this Windows worktree, and the remaining untested path is the intentional external-side-effect path behind a real tag push.

## Stacked PRs / Related

- None

## Knowledge for Future Reference

The release automation now has three distinct surfaces: registry publish jobs, post-publish verification, and GitHub Release creation. Only tag pushes exercise all three. `workflow_dispatch` remains the safe path for re-verifying an already-published version and should continue to skip GitHub Release creation unless the repo intentionally wants manual release-object editing later.

---
Authored-by: openai/gpt-5.4 (codex, effort: xhigh)
*Captain's log - partial delivery by [shiplog](https://github.com/devallibus/shiplog)*
