### PR TITLE
feat(#187): scaffold local-first starter path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,22 @@ jobs:
       - run: npm pack --dry-run --workspace=packages/runtime
       - run: npm pack --dry-run --workspace=packages/engine-ts
       - run: npm pack --dry-run --workspace=packages/shell
+
+  starter-smoke:
+    name: Starter Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: cargo install wasm-pack --locked
+      - run: bash tests/local-first-starter-smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Local-first starter scaffold (#187)** — `galeon new --preset local-first`
+  now generates a minimal runnable web starter: a Rust `crates/client` WASM
+  wrapper around `galeon-engine-three-sync`, a Rust-owned `StarterPlugin` in
+  `crates/domain` that guarantees a first renderable entity, a `client/`
+  Three.js app that consumes `@galeon/engine-ts`, and root Bun scripts for
+  `wasm`, `dev`, `build`, and `check`. CI now includes a starter smoke test
+  that scaffolds a fresh project and verifies the generated `bun run check` /
+  `bun run build` path end to end.
+
 - **`galeon routes` inspection command (#166)** — New top-level `galeon routes`
   command prints a deterministic route table for a Galeon project. Reuses the
   same scan → collect → resolve pipeline as `galeon generate routes` via a new

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ the engine itself is shell-agnostic.
 **CLI**
 - `galeon new <name> --preset <preset>` scaffolds a complete game project
 - Presets: `server-authoritative`, `local-first`, `hybrid`
+- `local-first` now scaffolds a minimal web starter with `bun run dev` /
+  `bun run build`; see [docs/guide/local-first-starter.md](docs/guide/local-first-starter.md)
 
 ## Quick Example
 

--- a/crates/galeon-cli/src/new.rs
+++ b/crates/galeon-cli/src/new.rs
@@ -23,6 +23,7 @@ pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Erro
     let include_server = matches!(preset, Preset::ServerAuthoritative | Preset::Hybrid);
     let include_db = matches!(preset, Preset::ServerAuthoritative);
     let include_docker = matches!(preset, Preset::ServerAuthoritative);
+    let include_local_first_starter = matches!(preset, Preset::LocalFirst);
 
     // Root workspace files
     fs::create_dir_all(&root)?;
@@ -31,11 +32,43 @@ pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Erro
         root.join("galeon.toml"),
         templates::galeon_toml(name, preset_str),
     )?;
+    fs::write(root.join(".gitignore"), templates::project_gitignore())?;
+    if include_local_first_starter {
+        fs::write(
+            root.join("package.json"),
+            templates::local_first_package_json(name),
+        )?;
+        fs::write(
+            root.join("README.md"),
+            templates::local_first_readme_md(name),
+        )?;
+    }
 
-    // client/ placeholder
+    // client/ web starter (local-first) or placeholder
     let client_dir = root.join("client");
     fs::create_dir_all(&client_dir)?;
-    fs::write(client_dir.join(".gitkeep"), "")?;
+    if include_local_first_starter {
+        let client_src = client_dir.join("src");
+        fs::create_dir_all(&client_src)?;
+        fs::write(
+            client_dir.join("tsconfig.json"),
+            templates::local_first_client_tsconfig_json(),
+        )?;
+        fs::write(
+            client_dir.join("index.html"),
+            templates::local_first_client_index_html(name),
+        )?;
+        fs::write(
+            client_src.join("main.ts"),
+            templates::local_first_client_main_ts(),
+        )?;
+        fs::write(
+            client_src.join("style.css"),
+            templates::local_first_client_style_css(),
+        )?;
+    } else {
+        fs::write(client_dir.join(".gitkeep"), "")?;
+    }
 
     // crates/protocol
     let protocol_src = root.join("crates").join("protocol").join("src");
@@ -56,7 +89,28 @@ pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Erro
         root.join("crates").join("domain").join("Cargo.toml"),
         templates::domain_cargo_toml(name),
     )?;
-    fs::write(domain_src.join("lib.rs"), templates::domain_lib_rs(name))?;
+    if include_local_first_starter {
+        fs::write(
+            domain_src.join("lib.rs"),
+            templates::local_first_domain_lib_rs(),
+        )?;
+    } else {
+        fs::write(domain_src.join("lib.rs"), templates::domain_lib_rs(name))?;
+    }
+
+    // crates/client (local-first)
+    if include_local_first_starter {
+        let wasm_src = root.join("crates").join("client").join("src");
+        fs::create_dir_all(&wasm_src)?;
+        fs::write(
+            root.join("crates").join("client").join("Cargo.toml"),
+            templates::local_first_client_cargo_toml(name),
+        )?;
+        fs::write(
+            wasm_src.join("lib.rs"),
+            templates::local_first_client_lib_rs(name),
+        )?;
+    }
 
     // crates/server (server-authoritative + hybrid)
     if include_server {
@@ -136,17 +190,52 @@ mod tests {
     fn test_scaffold_local_first() {
         let (_tmp, root) = run_scaffold("localgame", Preset::LocalFirst);
 
+        assert_file(&root, ".gitignore");
         assert_file(&root, "Cargo.toml");
         assert_file(&root, "galeon.toml");
-        assert_file(&root, "client/.gitkeep");
+        assert_file(&root, "package.json");
+        assert_file(&root, "README.md");
+        assert_file(&root, "client/index.html");
+        assert_file(&root, "client/tsconfig.json");
+        assert_file(&root, "client/src/main.ts");
+        assert_file(&root, "client/src/style.css");
         assert_file(&root, "crates/protocol/Cargo.toml");
         assert_file(&root, "crates/protocol/src/lib.rs");
         assert_file(&root, "crates/domain/Cargo.toml");
         assert_file(&root, "crates/domain/src/lib.rs");
+        assert_file(&root, "crates/client/Cargo.toml");
+        assert_file(&root, "crates/client/src/lib.rs");
 
         assert_no_file(&root, "crates/server/Cargo.toml");
         assert_no_file(&root, "crates/db/Cargo.toml");
         assert_no_file(&root, "docker-compose.yml");
+        assert_no_file(&root, "client/.gitkeep");
+
+        let package_json = fs::read_to_string(root.join("package.json")).unwrap();
+        assert!(package_json.contains(r#""dev": "bun run wasm && vite client""#));
+        assert!(package_json.contains(r#""build": "bun run wasm && vite build client""#));
+
+        let readme = fs::read_to_string(root.join("README.md")).unwrap();
+        assert!(readme.contains("bun run dev"));
+        assert!(readme.contains("bun run build"));
+
+        let domain = fs::read_to_string(
+            root.join("crates")
+                .join("domain")
+                .join("src")
+                .join("lib.rs"),
+        )
+        .unwrap();
+        assert!(domain.contains("StarterPlugin"));
+
+        let wasm_client = fs::read_to_string(
+            root.join("crates")
+                .join("client")
+                .join("src")
+                .join("lib.rs"),
+        )
+        .unwrap();
+        assert!(wasm_client.contains("StarterWasmEngine"));
     }
 
     #[test]

--- a/crates/galeon-cli/src/templates.rs
+++ b/crates/galeon-cli/src/templates.rs
@@ -17,10 +17,14 @@ pub fn galeon_toml(name: &str, preset: &str) -> String {
     format!(
         r#"[project]
 name = "{name}"
-engine = "0.1"
+engine = "0.2"
 preset = "{preset}"
 "#
     )
+}
+
+fn rust_crate_ident(name: &str) -> String {
+    name.replace('-', "_")
 }
 
 /// `crates/protocol/Cargo.toml`.
@@ -73,6 +77,34 @@ pub fn domain_lib_rs(name: &str) -> String {
 //! Game systems and handlers for {name}.
 "#
     )
+}
+
+/// `crates/domain/src/lib.rs` for the local-first starter preset.
+pub fn local_first_domain_lib_rs() -> String {
+    r#"// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+use galeon_engine::{Engine, MaterialHandle, MeshHandle, Plugin, Transform, Visibility};
+
+/// Minimal starter plugin that guarantees a first renderable entity.
+pub struct StarterPlugin;
+
+impl Plugin for StarterPlugin {
+    fn build(&self, engine: &mut Engine) {
+        engine.set_tick_rate(60.0);
+        engine.world_mut().spawn((
+            Transform {
+                position: [0.0, 0.35, 0.0],
+                rotation: [0.0, 0.0, 0.0, 1.0],
+                scale: [2.2, 0.7, 1.6],
+            },
+            Visibility { visible: true },
+            MeshHandle { id: 1 },
+            MaterialHandle { id: 1 },
+        ));
+    }
+}
+"#
+    .to_owned()
 }
 
 /// `crates/server/Cargo.toml` (server-authoritative and hybrid presets).
@@ -147,5 +179,409 @@ pub fn docker_compose_yml(name: &str) -> String {
 volumes:
   pgdata:
 "#
+    )
+}
+
+/// Root `.gitignore` for generated projects.
+pub fn project_gitignore() -> String {
+    r#"node_modules/
+target/
+dist/
+client/dist/
+client/pkg/
+"#
+    .to_owned()
+}
+
+/// Root `package.json` for the local-first starter preset.
+pub fn local_first_package_json(name: &str) -> String {
+    r#"{
+  "name": "__NAME__",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "wasm": "wasm-pack build crates/client --target web --out-dir ../../client/pkg --out-name starter",
+    "dev": "bun run wasm && vite client",
+    "build": "bun run wasm && vite build client",
+    "preview": "vite preview client",
+    "check": "bun run wasm && bunx tsc --project client/tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@galeon/engine-ts": "^0.2.0",
+    "three": "^0.183.2"
+  },
+  "devDependencies": {
+    "@types/three": "^0.183.1",
+    "typescript": "^5",
+    "vite": "^7"
+  }
+}
+"#
+        .replace("__NAME__", name)
+}
+
+/// Starter `README.md` for the local-first preset.
+pub fn local_first_readme_md(name: &str) -> String {
+    r#"# __NAME__
+
+Local-first Galeon starter project.
+
+## Prerequisites
+
+- Rust stable with `wasm32-unknown-unknown`
+- `wasm-pack`
+- Bun
+
+## Commands
+
+```bash
+bun install
+bun run dev
+```
+
+This builds the Rust WASM client crate into `client/pkg/` and starts a Vite dev
+server for the generated web starter.
+
+Production build:
+
+```bash
+bun run build
+```
+
+If you change Rust code while the dev server is running, rerun:
+
+```bash
+bun run wasm
+```
+
+## Project Layout
+
+- `crates/domain` — Rust-owned starter plugin and future game logic
+- `crates/client` — WASM wrapper exposed to the browser
+- `client/` — Three.js web client that consumes the extracted frame data
+- `crates/protocol` — protocol types for future commands/queries/events
+"#
+    .replace("__NAME__", name)
+}
+
+/// `client/tsconfig.json` for the local-first starter preset.
+pub fn local_first_client_tsconfig_json() -> String {
+    r#"{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}
+"#
+    .to_owned()
+}
+
+/// `client/index.html` for the local-first starter preset.
+pub fn local_first_client_index_html(name: &str) -> String {
+    r#"<!-- SPDX-License-Identifier: AGPL-3.0-only OR Commercial -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>__NAME__ | Galeon Starter</title>
+  </head>
+  <body>
+    <div class="shell">
+      <canvas id="viewport"></canvas>
+      <aside class="hud">
+        <p class="eyebrow">Galeon starter</p>
+        <h1>__NAME__</h1>
+        <p class="copy">
+          The first renderable entity comes from Rust. Three.js only owns the
+          scene graph and camera.
+        </p>
+        <dl class="commands">
+          <div>
+            <dt>Dev</dt>
+            <dd><code>bun run dev</code></dd>
+          </div>
+          <div>
+            <dt>Build</dt>
+            <dd><code>bun run build</code></dd>
+          </div>
+        </dl>
+      </aside>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+"#
+    .replace("__NAME__", name)
+}
+
+/// `client/src/main.ts` for the local-first starter preset.
+pub fn local_first_client_main_ts() -> String {
+    r##"// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import "./style.css";
+import { RendererCache } from "@galeon/engine-ts";
+import * as THREE from "three";
+import init, { StarterWasmEngine } from "../pkg/starter.js";
+
+const canvas = document.querySelector<HTMLCanvasElement>("#viewport");
+if (!canvas) {
+  throw new Error("missing #viewport canvas");
+}
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x08111f);
+scene.fog = new THREE.Fog(0x08111f, 9, 22);
+
+const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100);
+camera.position.set(5.5, 4.2, 6.5);
+camera.lookAt(0, 0.5, 0);
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+const ambient = new THREE.AmbientLight(0xf5f7ff, 0.65);
+scene.add(ambient);
+
+const sun = new THREE.DirectionalLight(0xfff1bf, 1.2);
+sun.position.set(6, 8, 4);
+scene.add(sun);
+
+const grid = new THREE.GridHelper(18, 18, 0x4f46e5, 0x1e293b);
+grid.position.y = -0.01;
+scene.add(grid);
+
+const cache = new RendererCache(scene);
+cache.registerGeometry(1, new THREE.BoxGeometry(1, 1, 1));
+cache.registerMaterial(
+  1,
+  new THREE.MeshStandardMaterial({
+    color: 0x38bdf8,
+    roughness: 0.45,
+    metalness: 0.08,
+  }),
+);
+
+function resizeRenderer(): void {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  renderer.setSize(width, height, false);
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  renderer.render(scene, camera);
+}
+
+window.addEventListener("resize", resizeRenderer);
+
+await init();
+const engine = new StarterWasmEngine();
+
+cache.applyFrame(engine.extract_frame());
+resizeRenderer();
+
+let lastFrame = performance.now();
+function frame(now: number): void {
+  const elapsed = Math.min((now - lastFrame) / 1000, 0.25);
+  lastFrame = now;
+
+  engine.tick(elapsed);
+  cache.applyFrame(engine.extract_frame());
+
+  if (cache.needsRender) {
+    renderer.render(scene, camera);
+  }
+
+  requestAnimationFrame(frame);
+}
+
+requestAnimationFrame(frame);
+"##
+    .to_owned()
+}
+
+/// `client/src/style.css` for the local-first starter preset.
+pub fn local_first_client_style_css() -> String {
+    r#"/* SPDX-License-Identifier: AGPL-3.0-only OR Commercial */
+
+:root {
+  color-scheme: dark;
+  --bg: #050b15;
+  --panel: rgba(8, 17, 31, 0.84);
+  --line: rgba(148, 163, 184, 0.18);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 36%),
+    linear-gradient(180deg, #07101d 0%, var(--bg) 100%);
+  color: var(--text);
+  font-family: "Segoe UI", "Inter", sans-serif;
+}
+
+body {
+  min-height: 100vh;
+}
+
+.shell {
+  position: relative;
+  min-height: 100vh;
+}
+
+#viewport {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+}
+
+.hud {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  width: min(360px, calc(100vw - 48px));
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 60px rgba(3, 8, 18, 0.45);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  color: var(--accent);
+}
+
+.hud h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.copy {
+  margin: 12px 0 18px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.commands {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.commands div {
+  display: grid;
+  gap: 4px;
+}
+
+.commands dt {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.commands dd {
+  margin: 0;
+}
+
+code {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 0.95rem;
+  color: #f8fafc;
+}
+
+@media (max-width: 640px) {
+  .hud {
+    top: auto;
+    bottom: 18px;
+    left: 18px;
+    width: calc(100vw - 36px);
+    padding: 18px;
+  }
+}
+"#
+    .to_owned()
+}
+
+/// `crates/client/Cargo.toml` for the local-first starter preset.
+pub fn local_first_client_cargo_toml(name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}-client"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+galeon-engine = "0.2.0"
+galeon-engine-three-sync = "0.2.0"
+wasm-bindgen = "0.2"
+{name}-domain = {{ path = "../domain" }}
+"#
+    )
+}
+
+/// `crates/client/src/lib.rs` for the local-first starter preset.
+pub fn local_first_client_lib_rs(name: &str) -> String {
+    r#"// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+use __DOMAIN_CRATE__::StarterPlugin;
+use galeon_engine::Engine;
+use galeon_engine_three_sync::{WasmEngine, WasmFramePacket};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct StarterWasmEngine {
+    inner: WasmEngine,
+}
+
+#[wasm_bindgen]
+impl StarterWasmEngine {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        let mut engine = Engine::new();
+        engine.add_plugin(StarterPlugin);
+        Self {
+            inner: WasmEngine::from_engine(engine),
+        }
+    }
+
+    pub fn tick(&mut self, elapsed: f64) -> u32 {
+        self.inner.tick(elapsed)
+    }
+
+    pub fn extract_frame(&self) -> WasmFramePacket {
+        self.inner.extract_frame()
+    }
+
+    pub fn debug_snapshot(&self) -> String {
+        self.inner.debug_snapshot()
+    }
+}
+"#
+    .replace(
+        "__DOMAIN_CRATE__",
+        &rust_crate_ident(&format!("{name}-domain")),
     )
 }

--- a/docs/guide/local-first-starter.md
+++ b/docs/guide/local-first-starter.md
@@ -1,0 +1,73 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only OR Commercial -->
+
+# Local-First Starter
+
+`galeon new <name> --preset local-first` now scaffolds a minimal web starter
+that can reach a first rendered frame without manual assembly.
+
+## What the Scaffold Includes
+
+- `crates/domain` with a Rust-owned `StarterPlugin` that spawns the first
+  renderable entity
+- `crates/client` as a small `wasm-bindgen` wrapper around
+  `galeon-engine-three-sync::WasmEngine`
+- `client/` as a Vite + Three.js web app that consumes `@galeon/engine-ts`
+- root `package.json` scripts for `wasm`, `dev`, `build`, and `check`
+
+The starter is intentionally narrow: one mesh, one camera, a small Three.js
+scene, and a documented build loop. It is a first runnable path, not an editor
+shell.
+
+## Prerequisites
+
+- Rust stable
+- `wasm32-unknown-unknown` target
+- `wasm-pack`
+- Bun
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+## Start the Starter
+
+From the generated project root:
+
+```bash
+bun install
+bun run dev
+```
+
+That flow:
+
+1. builds `crates/client` to `client/pkg/` with `wasm-pack`
+2. starts a Vite dev server rooted at `client/`
+3. renders the Rust-owned starter entity through `RendererCache`
+
+## Other Commands
+
+```bash
+bun run check
+bun run build
+```
+
+- `check` rebuilds the WASM client and type-checks the web app
+- `build` rebuilds the WASM client and emits a production Vite bundle
+
+If you change Rust code while the dev server is already running, rerun:
+
+```bash
+bun run wasm
+```
+
+## Where To Extend It
+
+- `crates/domain/src/lib.rs`
+  Add Rust-owned gameplay state, systems, and starter entities
+- `crates/client/src/lib.rs`
+  Adjust the browser-facing WASM exports
+- `client/src/main.ts`
+  Change the camera, renderer setup, and scene-side presentation
+- `crates/protocol/src/lib.rs`
+  Define protocol types when the project grows beyond the starter path

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+PROJECT_NAME="starter-smoke"
+PROJECT_DIR="$TMP_DIR/$PROJECT_NAME"
+
+find_tool() {
+  local name="$1"
+  local windows_home="${USERPROFILE:-}"
+
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+    return 0
+  fi
+
+  if command -v "${name}.exe" >/dev/null 2>&1; then
+    command -v "${name}.exe"
+    return 0
+  fi
+
+  if [[ -n "$windows_home" && -x "$windows_home/.cargo/bin/${name}.exe" ]]; then
+    printf '%s\n' "$windows_home/.cargo/bin/${name}.exe"
+    return 0
+  fi
+
+  if [[ -n "$windows_home" && -x "$windows_home/.bun/bin/${name}.exe" ]]; then
+    printf '%s\n' "$windows_home/.bun/bin/${name}.exe"
+    return 0
+  fi
+
+  return 1
+}
+
+normalize_path_for_tool() {
+  local path="$1"
+  local tool="$2"
+
+  if [[ "$tool" == *.exe ]] && command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$path"
+    return 0
+  fi
+
+  printf '%s\n' "$path"
+}
+
+CARGO_BIN="$(find_tool cargo)"
+BUN_BIN="$(find_tool bun)"
+REPO_MANIFEST="$(normalize_path_for_tool "$REPO_ROOT/Cargo.toml" "$CARGO_BIN")"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+pushd "$TMP_DIR" >/dev/null
+"$CARGO_BIN" run --manifest-path "$REPO_MANIFEST" -p galeon-cli -- new "$PROJECT_NAME" --preset local-first
+popd >/dev/null
+
+pushd "$PROJECT_DIR" >/dev/null
+"$BUN_BIN" install
+"$BUN_BIN" run check
+"$BUN_BIN" run build
+popd >/dev/null


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 187
branch: issue/187-local-first-starter
status: resolved
updated_at: 2026-04-21T09:50:57Z
-->

## Summary

This PR turns `galeon new --preset local-first` into a real starter path instead of a placeholder scaffold. Fresh local-first projects now get a Rust-owned starter entity, a generated WASM wrapper crate, a Three.js web client, Bun-based dev/build scripts, and a starter smoke test path in CI.

Closes #187

## Journey Timeline

### Initial Plan
Close the gap between “project structure exists” and “a generated local-first project can actually reach a first rendered frame” without inventing a parallel non-Rust runtime path.

### What We Discovered
- The current in-tree TypeScript surface is asymmetric: `@galeon/engine-ts` is the real Three.js consumer, while `@galeon/runtime` and `@galeon/shell` are intentionally thin placeholders. That made a generated web starter the cleanest implementation path.
- Galeon already had the right seam for a Rust-first starter in `galeon-engine-three-sync`: a thin app-owned wrapper crate can bootstrap a real engine and expose `WasmEngine` output to JS.
- The first scaffold pass passed `bun run build` but failed `bun run check` because wasm-bindgen’s generated declarations referenced `Symbol.dispose`; the generated `client/tsconfig.json` had to move to `ESNext` libs to make the starter self-consistent.

### Implementation Issues
- The smoke script is written for CI/Linux and a normal POSIX shell. Local verification in this Windows environment used the equivalent PowerShell flow because Git Bash path translation and `cargo.exe` do not compose cleanly enough to treat the shell script itself as the local oracle.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Starter contract | Generate a Rust-owned starter entity plus a small web client | Keeps gameplay/bootstrap ownership in Rust while giving downstream users a runnable first-frame path |
| Dev entrypoint | Generated Bun scripts instead of a new `galeon dev` command | Delivers a concrete workflow within the scope of this issue without expanding the CLI surface prematurely |
| Verification strategy | Add a starter smoke script and CI job, then locally verify a fresh scaffold with `bun install`, `bun run check`, and `bun run build` | Tests the generated downstream project instead of only asserting template strings |
| Documentation surface | Add a repo guide and README pointer alongside the generated project README | Makes the new starter path visible in Galeon’s public workflow, not just inside generated files |

### Changes Made

**Commits:**
- `0ed8dfa` feat(#187): scaffold local-first starter path

## Testing

- [x] `cargo test -p galeon-cli`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Fresh `galeon new starter-verify --preset local-first`
- [x] Fresh `bun install`
- [x] Fresh `bun run check`
- [x] Fresh `bun run build`
- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities

**Verification summary:** The generated project now scaffolds a minimal Rust+WASM+Three starter, type-checks with the generated TS config, builds its wasm package through `wasm-pack`, and produces a Vite bundle without manual project edits.

## Stacked PRs / Related

- #185
- #188

## Knowledge for Future Reference

The starter path depends on the published downstream surface, not just the monorepo internals. Template changes in `galeon new` need to be tested by generating a real project and exercising its own commands, because that is the contract consumers actually feel.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*