### PR TITLE
docs(#185): document current CLI getting-started flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Honest CLI getting-started docs (#185)** — README and
+  `docs/guide/cli-getting-started.md` now document the current CLI surface
+  (`new`, `generate`, `routes`), explain that only `local-first` currently
+  scaffolds a runnable `bun run dev` path, clarify that `server-authoritative`
+  and `hybrid` still stop at project structure, and link the planned generic
+  `galeon dev` / watch workflow issues (#74, #165).
+
 - **`World` is `Send` for axum shared state (#173)** — Resources store
   `Box<dyn Any + Send>`; deferred commands and event/deadline callbacks are
   `Send`; `Clock` is `Send + Sync`; `Res`/`ResMut` and `EventReader`/`EventWriter`

--- a/README.md
+++ b/README.md
@@ -66,10 +66,35 @@ the engine itself is shell-agnostic.
 - Fallback geometry for missing assets
 
 **CLI**
-- `galeon new <name> --preset <preset>` scaffolds a complete game project
+- `galeon new <name> --preset <preset>` scaffolds a preset-specific Galeon project
 - Presets: `server-authoritative`, `local-first`, `hybrid`
-- `local-first` now scaffolds a minimal web starter with `bun run dev` /
-  `bun run build`; see [docs/guide/local-first-starter.md](docs/guide/local-first-starter.md)
+- `local-first` is the only preset that currently scaffolds a runnable web
+  starter with `bun run dev` / `bun run build`; see
+  [docs/guide/local-first-starter.md](docs/guide/local-first-starter.md)
+- `server-authoritative` and `hybrid` scaffold Rust-first workspace structure
+  and client seams, not a ready-to-run shell
+- `galeon generate <ts|manifest|descriptors|routes>` emits project artifacts
+- `galeon routes` prints the effective route table for the current project
+
+## CLI Getting Started
+
+Today Galeon's CLI covers scaffolding, artifact generation, and route
+inspection. It does not yet provide a universal `galeon dev`, `galeon run`, or
+`galeon build` entrypoint.
+
+For the current preset-by-preset flow:
+
+- start with
+  [docs/guide/cli-getting-started.md](docs/guide/cli-getting-started.md)
+- use
+  [docs/guide/local-first-starter.md](docs/guide/local-first-starter.md) for
+  the runnable `local-first` starter
+- use [docs/guide/protocol.md](docs/guide/protocol.md) for
+  `galeon generate` outputs and protocol boundary details
+
+Roadmap for the missing generic dev/watch workflow lives in
+[#74](https://github.com/galeon-engine/galeon/issues/74) and
+[#165](https://github.com/galeon-engine/galeon/issues/165).
 
 ## Quick Example
 
@@ -103,7 +128,7 @@ crates/
   engine-macros/       Proc-macro crate (#[derive(Component)], #[command], etc.)
   engine/              Core ECS, scheduler, protocol, data loading
   engine-three-sync/   WASM bridge — packed ECS snapshots to Three.js
-  galeon-cli/          CLI binary (galeon new)
+  galeon-cli/          CLI binary (galeon new / generate / routes)
 
 packages/
   runtime/             @galeon/runtime — JS/WASM glue

--- a/docs/guide/cli-getting-started.md
+++ b/docs/guide/cli-getting-started.md
@@ -1,0 +1,109 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only OR Commercial -->
+
+# CLI Getting Started
+
+This guide documents the current `galeon-cli` surface as it exists today.
+Galeon can scaffold projects, generate protocol artifacts, and inspect resolved
+routes. It does not yet expose a universal `galeon dev`, `galeon run`, or
+`galeon build` command.
+
+## Current Commands
+
+```bash
+galeon new <name> --preset <server-authoritative|local-first|hybrid>
+galeon generate ts
+galeon generate manifest
+galeon generate descriptors
+galeon generate routes
+galeon routes
+```
+
+- `galeon new` creates a new project directory under the current working
+  directory
+- `galeon generate ...` runs inside an existing Galeon project and writes files
+  under `generated/` by default
+- `galeon routes` prints the effective route table for the current project
+
+`galeon generate` and `galeon routes` both walk up from the current working
+directory until they find `galeon.toml`, so you can run them from the project
+root or from a nested crate directory.
+
+## Pick A Preset
+
+| Preset | What `galeon new` creates today | Ready-to-run path |
+|--------|---------------------------------|-------------------|
+| `local-first` | `crates/protocol`, `crates/domain`, `crates/client`, `client/`, root `package.json`, and a generated starter `README.md` | Yes. Run `bun install`, then `bun run dev`. |
+| `server-authoritative` | `crates/protocol`, `crates/domain`, `crates/server`, `crates/db`, `docker-compose.yml`, and a placeholder `client/.gitkeep` | No. This preset scaffolds project structure only. |
+| `hybrid` | `crates/protocol`, `crates/domain`, `crates/server`, and a placeholder `client/.gitkeep` | No. This preset scaffolds project structure only. |
+
+Only `local-first` currently includes a documented starter loop. The other two
+presets give you the Rust workspace layout and expected crate boundaries, but
+you still add the runtime shell, transport glue, and app-specific boot flow.
+
+## Local-First: First Running Project
+
+Use `local-first` when you want the shortest path to a first rendered frame:
+
+```bash
+galeon new my-game --preset local-first
+cd my-game
+bun install
+bun run dev
+```
+
+That flow:
+
+1. creates a Rust-owned `StarterPlugin` in `crates/domain`
+2. creates a `crates/client` WASM wrapper around
+   `galeon-engine-three-sync::WasmEngine`
+3. creates a `client/` Vite + Three.js app that consumes `@galeon/engine-ts`
+4. builds `crates/client` into `client/pkg/` with `wasm-pack`
+5. starts the generated web starter through Vite
+
+The generated project root also includes a starter README with the same
+commands. For the detailed starter workflow, see
+[local-first-starter.md](local-first-starter.md).
+
+## Server-Authoritative And Hybrid: What Is Still Missing
+
+`server-authoritative` and `hybrid` are intentionally more skeletal today.
+After `galeon new`, you have the crate layout and config, but you do not yet get
+any of the following by default:
+
+- a generated browser client or desktop shell
+- a universal `galeon dev` / `galeon run` command
+- a watch loop that rebuilds codegen and launches runtime pieces for you
+
+For these presets, the next step is to add your own server/runtime entrypoint,
+client shell, and transport boundary on top of the scaffolded `protocol`,
+`domain`, and `server` crates.
+
+## Artifact Generation After Scaffolding
+
+Inside any Galeon project, the CLI can emit protocol and transport artifacts:
+
+| Command | Default output |
+|---------|----------------|
+| `galeon generate ts` | `generated/types.ts` |
+| `galeon generate manifest` | `generated/manifest.json` |
+| `galeon generate descriptors` | `generated/descriptors.json` |
+| `galeon generate routes` | `generated/routes.rs` |
+
+Use `--out <path>` on any `galeon generate` subcommand to override the default
+destination. `galeon routes` is read-only: it prints the resolved route table
+instead of writing a file.
+
+For the protocol model behind these outputs, see
+[protocol.md](protocol.md).
+
+## Not Here Yet
+
+The missing generic workflow is intentional roadmap, not a hidden command:
+
+- [#74](https://github.com/galeon-engine/galeon/issues/74) tracks a future
+  `galeon dev` / `galeon build` transport-aware flow
+- [#165](https://github.com/galeon-engine/galeon/issues/165) tracks a future
+  `galeon dev` watch mode for filesystem API autogen
+
+Until those land, treat Galeon's CLI as a project scaffold plus artifact/codegen
+tooling, with the `local-first` preset as the only built-in runnable starter.

--- a/docs/guide/local-first-starter.md
+++ b/docs/guide/local-first-starter.md
@@ -5,6 +5,9 @@
 `galeon new <name> --preset local-first` now scaffolds a minimal web starter
 that can reach a first rendered frame without manual assembly.
 
+For the full CLI surface, the non-runnable presets, and the current codegen
+commands, see [cli-getting-started.md](cli-getting-started.md).
+
 ## What the Scaffold Includes
 
 - `crates/domain` with a Rust-owned `StarterPlugin` that spawns the first
@@ -13,6 +16,7 @@ that can reach a first rendered frame without manual assembly.
   `galeon-engine-three-sync::WasmEngine`
 - `client/` as a Vite + Three.js web app that consumes `@galeon/engine-ts`
 - root `package.json` scripts for `wasm`, `dev`, `build`, and `check`
+- a generated project `README.md` that repeats the starter commands
 
 The starter is intentionally narrow: one mesh, one camera, a small Three.js
 scene, and a documented build loop. It is a first runnable path, not an editor


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 185
branch: issue/185-honest-cli-getting-started-flow
status: resolved
updated_at: 2026-04-21T11:18:00Z
-->

## Summary

This PR updates Galeon's public getting-started docs to match the current CLI surface on `master`. It documents `galeon new`, `galeon generate`, and `galeon routes`, makes the preset-specific runnable-vs-structure-only boundary explicit, and links the still-missing generic `galeon dev` / watch workflow to the roadmap instead of implying hidden commands.

Closes #185

## Journey Timeline

### Initial Plan
Use #185 to document the real contributor path after the starter work landed, with one guide that explains what the CLI does today and what remains planned.

### What We Discovered
- The original #185 issue text had drifted behind `master`: `galeon routes` already exists and `local-first` already scaffolds a documented `bun run dev` path.
- The main docs gap was no longer "there is no runnable starter" globally; it was that only one preset is runnable and that boundary was not stated clearly.

### Implementation Issues
- While updating the issue envelope, a nested PowerShell body rewrite collapsed markdown line breaks. The canonical issue body was repaired immediately and the implementation issue was recorded on #185 before continuing.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Getting-started doc shape | Added `docs/guide/cli-getting-started.md` and cross-linked it from README and the local-first guide | Keeps the README short while giving one canonical current-state walkthrough |
| Preset messaging | State explicitly that only `local-first` is runnable today | Avoids promising runtime flows that do not exist for `server-authoritative` and `hybrid` |
| Roadmap treatment | Linked #74 and #165 instead of hand-waving future `galeon dev` support | Makes missing commands read as planned work rather than silent omission |

### Changes Made

**Commits:**
- `a6f5f58` docs(#185): document current CLI getting-started flow

## Testing

- [x] Checked `target\debug\galeon.exe --help`, `new --help`, and `generate --help`
- [x] Scaffolded throwaway `server-authoritative`, `local-first`, and `hybrid` projects to verify generated file layouts
- [x] Compared the generated local-first project README with the documented `bun install` / `bun run dev` flow
- [x] Ran `git diff --check`
- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities

**Verification summary:** Docs only. No code paths changed. Verification focused on matching the written guidance to the live CLI help surface and the actual scaffold outputs.

## Review Gate

Independent cross-model review is required before merge per **shiplog**.

## Stacked PRs / Related

- #74
- #165
- #166
- #187

## Knowledge for Future Reference

When the CLI surface changes, update the getting-started guide, the README CLI summary, and any preset-specific guide in the same PR. The contributor problem here was drift between current scaffold behavior and older documentation, not missing depth.

---
Authored-by: openai/gpt-5.4 (codex, effort: xhigh)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
