### PR TITLE
docs(#184): clarify workspace package surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `hybrid` still stop at project structure, and link the planned generic
   `galeon dev` / watch workflow issues (#74, #165).
 
+- **Package/workspace docs now match the checked-in TS surface (#184)** —
+  README and the publishing guide now state explicitly that
+  `packages/runtime`, `packages/engine-ts`, and `packages/shell` are checked-in
+  workspace packages and also the published `@galeon/*` npm surface, clarify
+  what the root Bun commands operate on, and add a package-surface maintenance
+  rule to keep workspace docs aligned with the repository layout.
+
 - **`World` is `Send` for axum shared state (#173)** — Resources store
   `Box<dyn Any + Send>`; deferred commands and event/deadline callbacks are
   `Send`; `Clock` is `Send + Sync`; `Res`/`ResMut` and `EventReader`/`EventWriter`

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ crates/
   galeon-cli/          CLI binary (galeon new / generate / routes)
 
 packages/
-  runtime/             @galeon/runtime — JS/WASM glue
-  engine-ts/           @galeon/engine-ts — Three.js RendererCache
-  shell/               @galeon/shell — editor UI (Solid.js, planned)
+  runtime/             @galeon/runtime — JS/WASM glue (workspace + npm package)
+  engine-ts/           @galeon/engine-ts — Three.js RendererCache (workspace + npm package)
+  shell/               @galeon/shell — editor UI package (workspace + npm package, experimental)
 ```
 
 Crate dependency graph:
@@ -171,10 +171,18 @@ bun install
 bun run check    # Type-check all packages (tsc --build)
 ```
 
+The Bun workspace in this repository is the checked-in `packages/*` tree:
+`packages/runtime`, `packages/engine-ts`, and `packages/shell`. These are the
+same packages that publish to npm under the `@galeon/*` scope; they are not a
+separate publish-only surface outside this checkout.
+
 ## Public Packages
 
 Galeon publishes **three Rust crates** to [crates.io](https://crates.io) and
 **three TypeScript packages** to [npm](https://www.npmjs.com).
+
+The TypeScript packages listed here are also checked into this repository under
+`packages/*` and are the packages targeted by the root Bun workspace commands.
 
 ### Rust crates
 
@@ -190,7 +198,7 @@ Galeon publishes **three Rust crates** to [crates.io](https://crates.io) and
 |---------|-----|-------------|
 | `@galeon/runtime` | [![npm](https://img.shields.io/npm/v/@galeon/runtime)](https://www.npmjs.com/package/@galeon/runtime) | JS &harr; WASM glue |
 | `@galeon/engine-ts` | [![npm](https://img.shields.io/npm/v/@galeon/engine-ts)](https://www.npmjs.com/package/@galeon/engine-ts) | Three.js RendererCache |
-| `@galeon/shell` | [![npm](https://img.shields.io/npm/v/@galeon/shell)](https://www.npmjs.com/package/@galeon/shell) | Editor UI (Solid.js, planned) |
+| `@galeon/shell` | [![npm](https://img.shields.io/npm/v/@galeon/shell)](https://www.npmjs.com/package/@galeon/shell) | Editor UI package (experimental) |
 
 ### Not published
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -7,6 +7,10 @@
 Galeon publishes **three Rust crates** to crates.io and **three TypeScript
 packages** to npm. Everything else in the workspace is internal.
 
+The npm packages in this guide are the checked-in workspace packages under
+`packages/runtime`, `packages/engine-ts`, and `packages/shell`. They are not a
+separate external-only package surface.
+
 ## Publish surfaces
 
 ### Rust crates (crates.io)
@@ -93,6 +97,9 @@ npm pack --dry-run --workspace=packages/engine-ts
 npm pack --dry-run --workspace=packages/shell
 ```
 
+At the repo root, `bun run check` and `bun run build` both run `tsc --build`
+across these same checked-in workspace packages.
+
 ## Release procedure
 
 1. Run `bash scripts/bump-version.sh A.B.C` (see version bump checklist above).
@@ -163,3 +170,15 @@ and pin to it. Read the [changelog](../../CHANGELOG.md) on each upgrade.
   under the `alpha` npm dist-tag.
 
 For the full stability statement, see the [README](../../README.md#stability).
+
+## Package Surface Maintenance Rule
+
+If the TypeScript package surface changes in a way contributors can see
+(package added, removed, renamed, moved out of `packages/*`, or changed between
+published and internal), update these surfaces in the same PR:
+
+1. root `package.json` workspace entries
+2. `tsconfig.base.json` path aliases
+3. README architecture, TypeScript build, and public package sections
+4. this publishing guide
+5. CI/release workflow references if publishability changed


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 184
branch: issue/184-align-package-workspace-docs
status: resolved
updated_at: 2026-04-21T11:37:00Z
updated_by: openai/gpt-5.4 (codex, effort: xhigh)
edit_kind: rewrite
-->

## Summary

This PR updates Galeon's public docs so they describe the current TypeScript package surface accurately: the checked-in `packages/*` workspace is the same surface that publishes `@galeon/*` to npm. It also clarifies what the root Bun workspace commands operate on and adds a maintenance rule so future package-surface changes update the docs in the same PR.

Closes #184

## Journey Timeline

### Initial Plan
Use #184 to reconcile README and package/workspace guidance with the actual repository contents and remove contributor ambiguity around the TypeScript layer.

### What We Discovered
- The original #184 issue body had drifted behind `master`: the `packages/*` workspace is present in-tree again, so the real docs gap was no longer a missing checkout surface.
- The remaining problem was that the docs never said explicitly that the checked-in workspace packages are also the published `@galeon/*` npm packages.

### Implementation Issues
- Verification uncovered a real but separate TypeScript workspace problem: `bun run check` currently fails in `packages/engine-ts` because `three` resolution and browser typings are not configured cleanly for the checked-in workspace build. That was captured as #194 instead of widening this docs PR into a config fix.
- After #193 merged first, this branch had to be rebased onto the updated `master` because both PRs touched `README.md` and `CHANGELOG.md`. The rebase kept both docs entries and did not change the intended #184 content.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Current-state framing | Rewrite the issue/docs around the real current problem instead of preserving the stale "packages are missing" premise | Keeps the public docs aligned with `master` rather than with an outdated snapshot |
| Package status wording | State that `packages/runtime`, `packages/engine-ts`, and `packages/shell` are both checked-in workspace packages and the published npm surface | Removes the ambiguity between in-tree code and release artifacts |
| Drift prevention | Add a package-surface maintenance rule to the publishing guide | Makes future workspace/package changes update docs and workflow references together |

### Changes Made

**Commits:**
- `9cc3793` docs(#184): clarify workspace package surface

## Testing

- [x] Confirmed the checked-in `packages/runtime`, `packages/engine-ts`, and `packages/shell` trees exist on current `master`
- [x] Reviewed root `package.json`, `tsconfig.base.json`, and the package manifests to verify the workspace/package relationship
- [x] Ran `npm pack --dry-run --workspace=packages/runtime`
- [x] Ran `npm pack --dry-run --workspace=packages/engine-ts`
- [x] Ran `npm pack --dry-run --workspace=packages/shell`
- [x] Ran `git diff --check`
- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities

**Verification summary:** The docs changes match the checked-in workspace/package layout. Root `bun run check` is still failing for a separate `engine-ts` typing/config reason, which is tracked in #194 and intentionally left out of this docs PR.

## Review Gate

Independent cross-model review is required before merge per **shiplog**.

## Stacked PRs / Related

- #194

## Knowledge for Future Reference

When the TypeScript package surface changes, update the root workspace metadata, README package sections, publishing guide, and workflow references together. The main drift vector here was not code removal; it was docs failing to explain that the in-tree workspace and the npm publish surface are the same packages.

---
Authored-by: openai/gpt-5.4 (codex, effort: xhigh)
Updated-by: openai/gpt-5.4 (codex, effort: xhigh)
Edit-kind: rewrite
Edit-note: Rebased the PR after #193 merged first, updated the recorded commit SHA, and documented the shared-file overlap in the timeline.
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
