### PR TITLE
fix(#194): intentional DOM lib for TypeScript workspace check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,15 +95,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **TypeScript workspace `bun run check` (#194)** — Added `DOM` and
-  `DOM.Iterable` to `tsconfig.base.json`'s `lib` array so browser globals
-  used by `@galeon/engine-ts` (`console.warn` in `renderer-cache.ts`, and the
-  Three.js / Web types consumed transitively) are declared intentionally
-  instead of relying on the ambient `@types/bun` declarations. The `three`
-  dependency is declared correctly in `packages/engine-ts/package.json` and
-  resolves via `bun install`; the reported failure was an unconfigured lib
-  surface, not a missing dep. `bun run check` now passes cleanly from the
-  repo root after `bun install`.
+- **TypeScript workspace `bun run check` (#194)** — Declared workspace type
+  surface intentionally in `tsconfig.base.json`: added `DOM` and
+  `DOM.Iterable` to `lib` (for `console.warn` in `renderer-cache.ts` and the
+  Web/Canvas types Three.js pulls in), and set `types: []` so TypeScript no
+  longer auto-loads every `@types/*` package (previously `@types/bun`'s
+  ambient declarations silently satisfied `console`). `three` and
+  `@types/three` are declared in `packages/engine-ts/package.json` and
+  resolve via `bun install` through normal module resolution; the reported
+  `TS2307` reproduces only without a prior install. `bun run check` now
+  passes cleanly from the repo root, and `tsc --explainFiles` confirms the
+  engine-ts build pulls in `lib.dom*.d.ts` from `compilerOptions` and no
+  ambient `@types/*`.
 
 - **Shiplog label drift (#103)** — Audited all open issues and backfilled
   lifecycle labels (`shiplog/ready`, `shiplog/in-progress`) to match envelope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **TypeScript workspace `bun run check` (#194)** — Added `DOM` and
+  `DOM.Iterable` to `tsconfig.base.json`'s `lib` array so browser globals
+  used by `@galeon/engine-ts` (`console.warn` in `renderer-cache.ts`, and the
+  Three.js / Web types consumed transitively) are declared intentionally
+  instead of relying on the ambient `@types/bun` declarations. The `three`
+  dependency is declared correctly in `packages/engine-ts/package.json` and
+  resolves via `bun install`; the reported failure was an unconfigured lib
+  surface, not a missing dep. `bun run check` now passes cleanly from the
+  repo root after `bun install`.
+
 - **Shiplog label drift (#103)** — Audited all open issues and backfilled
   lifecycle labels (`shiplog/ready`, `shiplog/in-progress`) to match envelope
   `readiness` fields. Added `docs/guide/shiplog-labels.md` with the label

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": [],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary

- Add `DOM` and `DOM.Iterable` to `tsconfig.base.json`'s `lib` array so `@galeon/engine-ts` resolves browser globals (`console.warn` in `renderer-cache.ts`, plus Web/Canvas types used transitively by Three.js) from an intentional lib declaration — not from ambient `@types/bun` declarations.
- Verify `bun run check` passes cleanly from the repo root after `bun install`, and verify the reported `three` resolution failure was an install-not-run issue, not a dep-surface issue (deps are correctly declared and locked).
- Record the change in CHANGELOG `[Unreleased] ### Fixed`.

Closes #194

## Journey Timeline

### Initial Plan

Reproduce `bun run check` failures from a clean worktree, inspect `packages/engine-ts/package.json` + `tsconfig.json` vs. `tsconfig.base.json`, add any missing deps via `bun add`, adjust `compilerOptions.lib` to include DOM where browser globals are used, then re-run `bun run check`.

### What We Discovered

- **T1 is not a dep-surface bug.** `three` and `@types/three` are already declared in `packages/engine-ts/package.json` (dependencies / devDependencies respectively) and both are locked in `bun.lock`. They resolve via Bun's workspace symlinks (`packages/engine-ts/node_modules/three -> ../../node_modules/.bun/three@0.183.2/...`).
- The issue's `TS2307: Cannot find module 'three'` reproduces **only when `bun run check` is run without a prior `bun install`** (confirmed by nuking `node_modules` and re-running). After install, `three` resolves cleanly.
- **T2 is the real latent bug.** With `"lib": ["ESNext"]` in the base tsconfig, `console.warn` in `renderer-cache.ts` has no declaration from the lib. It only type-checks because `@types/bun` is present in every package's `devDependencies` and declares `console` as an ambient global — exactly the "ambient accident" the issue's acceptance criteria call out.

### Key Decisions Made

| Decision | Rationale |
|---|---|
| Put the DOM lib entry in `tsconfig.base.json`, not just `packages/engine-ts/tsconfig.json` | All three packages ship to the browser at runtime: `engine-ts` drives Three.js scene graph updates; `shell` is a Solid.js editor UI; `runtime` is the JS↔WASM invoke/events bridge. Declaring DOM once in the base keeps them consistent and avoids per-package drift later. |
| Add both `DOM` and `DOM.Iterable` | `DOM.Iterable` is the standard companion for iterating `NodeList`, `HTMLCollection`, and similar DOM collections. TypeScript's template default pairs them. |
| No code change for T1 | The issue's acceptance criterion for T1 ("resolves its declared dependencies during workspace type-checking") is met by the existing dep declarations + lockfile after `bun install`. Adding a redundant re-declaration would be noise. |
| Keep `@types/bun` in package devDependencies | Still legitimately used for `bun:test` in `packages/engine-ts/tests/` and the `Bun.` namespace. It is no longer load-bearing for `console` after this change. |

### Changes Made

- `1dc572d fix(#194/T2): intentional DOM lib for workspace type-check` — `tsconfig.base.json`: `lib: ["ESNext"]` → `lib: ["ESNext", "DOM", "DOM.Iterable"]`; CHANGELOG `[Unreleased] ### Fixed` entry.

## Testing

- [x] Reproduced the issue's exact three errors on a clean worktree (no `bun install`): `TS2307` for `three`, two `TS2584` for `console`.
- [x] Confirmed `bun install` alone makes the `three` error go away (workspace symlinks verified at `packages/engine-ts/node_modules/three`).
- [x] Applied the DOM lib change, re-ran `bunx tsc --build --clean` then `bun run check` → exit 0, no output.
- [x] End-to-end fresh-state verification: `rm -rf node_modules packages/*/node_modules packages/*/dist packages/*/tsconfig.tsbuildinfo` + `bun install` + `bun run check` → exit 0, no output.
- [x] Verified no Bun-specific APIs used in `packages/*/src` (only `packages/engine-ts/tests/renderer-cache.test.ts` uses `bun:test`, and tests are outside the `include: ["src"]` build graph).

## Knowledge for Future Reference

- The workspace's `check` script relies on deps being installed — standard, but worth remembering when triaging "works on my machine" type-check reports. First question when a `bun run check` failure cites `TS2307` for a declared dep: was `bun install` run against the current `bun.lock`?
- `@types/bun` globally declares `console` (among many other Web-API shaped globals). Relying on it for browser globals in a non-Bun-test code path is fragile — if we ever remove it from a browser-targeted package, the build breaks in non-obvious ways. Explicit `lib: [..., "DOM", "DOM.Iterable"]` in the tsconfig for any browser-targeted package is the durable fix.
- `tsconfig.base.json` extends into all three `packages/*/tsconfig.json` via the workspace composite setup, so lib additions there propagate to every package without per-package churn.

---
Authored-by: anthropic/claude-opus-4.7 (claude-code)
*Captain's log -- PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
