### PR TITLE
feat(#197): publish galeon-cli as supported install surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - run: cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync
       # Packaging resolves registry deps; engine/three-sync need prior crates on crates.io.
       - run: cargo publish -p galeon-engine-macros --dry-run
+      - run: cargo publish -p galeon-cli --dry-run
 
   typescript:
     name: TypeScript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,9 +266,11 @@ jobs:
           node -e "import('@galeon/runtime').then(() => console.log('@galeon/runtime OK'))"
 
       - name: Verify CLI — installed binary starter bootstrap
-        env:
-          GALEON_INSTALL_VERSION: ${{ env.VERSION }}
-        run: bash tests/local-first-starter-smoke.sh
+        run: |
+          : "${VERSION:?Resolve version step did not set VERSION}"
+          export GALEON_REQUIRE_PUBLISHED=1
+          export GALEON_INSTALL_VERSION="${VERSION}"
+          bash tests/local-first-starter-smoke.sh
 
   release-evidence:
     name: Release Evidence Bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,20 +185,55 @@ jobs:
           cd packages/shell
           npm publish --access public --tag "$NPM_DIST_TAG" --provenance
 
+  publish-cli:
+    if: github.event_name != 'workflow_dispatch'
+    needs: [publish-crates, publish-npm]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish galeon-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set +e
+          output="$(cargo publish -p galeon-cli 2>&1)"
+          status=$?
+          set -e
+          echo "$output"
+          if [ $status -eq 0 ]; then exit 0; fi
+          if [[ "$output" == *"already exists on crates.io index"* ]]; then
+            echo "galeon-cli already published; skipping."
+            exit 0
+          fi
+          exit $status
+
   verify-publish:
     name: Verify Published Artifacts
-    needs: [publish-npm, publish-crates]
+    needs: [publish-npm, publish-crates, publish-cli]
     if: >-
       always() && !cancelled() && (
         github.event_name == 'workflow_dispatch' ||
-        (needs.publish-npm.result == 'success' && needs.publish-crates.result == 'success')
+        (
+          needs.publish-npm.result == 'success' &&
+          needs.publish-crates.result == 'success' &&
+          needs.publish-cli.result == 'success'
+        )
       )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Resolve version
         run: |
@@ -230,15 +265,24 @@ jobs:
           npm install "@galeon/runtime@${VERSION}"
           node -e "import('@galeon/runtime').then(() => console.log('@galeon/runtime OK'))"
 
+      - name: Verify CLI — installed binary starter bootstrap
+        env:
+          GALEON_INSTALL_VERSION: ${{ env.VERSION }}
+        run: bash tests/local-first-starter-smoke.sh
+
   release-evidence:
     name: Release Evidence Bundle
-    needs: [publish-npm, publish-crates, verify-publish]
+    needs: [publish-npm, publish-crates, publish-cli, verify-publish]
     if: >-
       always() && !cancelled() &&
       needs.verify-publish.result == 'success' &&
       (
         github.event_name == 'workflow_dispatch' ||
-        (needs.publish-npm.result == 'success' && needs.publish-crates.result == 'success')
+        (
+          needs.publish-npm.result == 'success' &&
+          needs.publish-crates.result == 'success' &&
+          needs.publish-cli.result == 'success'
+        )
       )
     runs-on: ubuntu-latest
     steps:
@@ -253,6 +297,7 @@ jobs:
 
       - name: Build evidence markdown
         env:
+          PUBLISH_CLI_RESULT: ${{ needs.publish-cli.result }}
           PUBLISH_NPM_RESULT: ${{ needs.publish-npm.result }}
           PUBLISH_CRATES_RESULT: ${{ needs.publish-crates.result }}
           VERIFY_RESULT: ${{ needs.verify-publish.result }}
@@ -266,6 +311,7 @@ jobs:
           - Run URL: ${run_url}
           - publish-crates: ${PUBLISH_CRATES_RESULT}
           - publish-npm: ${PUBLISH_NPM_RESULT}
+          - publish-cli: ${PUBLISH_CLI_RESULT}
           - verify-publish: ${VERIFY_RESULT}
 
           ## References
@@ -283,12 +329,13 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: [publish-npm, publish-crates, verify-publish, release-evidence]
+    needs: [publish-npm, publish-crates, publish-cli, verify-publish, release-evidence]
     if: >-
       github.event_name != 'workflow_dispatch' &&
       !cancelled() &&
       needs.publish-npm.result == 'success' &&
       needs.publish-crates.result == 'success' &&
+      needs.publish-cli.result == 'success' &&
       needs.verify-publish.result == 'success' &&
       needs.release-evidence.result == 'success'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Published `galeon-cli` install surface (#197)** — `galeon-cli` is now part
+  of the supported crates.io surface. The CLI inherits the workspace release
+  version, scaffolds the matching Galeon crate/package version from the
+  installed binary instead of hardcoded template versions, CI now runs
+  `cargo publish --dry-run -p galeon-cli`, the starter smoke test installs the
+  CLI before scaffolding, and the release workflow publishes/verifies the CLI
+  after the library and npm starter artifacts.
+
 - **Local-first starter scaffold (#187)** — `galeon new --preset local-first`
   now generates a minimal runnable web starter: a Rust `crates/client` WASM
   wrapper around `galeon-engine-three-sync`, a Rust-owned `StarterPlugin` in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -155,7 +155,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "galeon-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "serde",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/galeon-engine/galeon/actions/workflows/ci.yml/badge.svg)](https://github.com/galeon-engine/galeon/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/galeon-engine)](https://crates.io/crates/galeon-engine)
+[![cli](https://img.shields.io/crates/v/galeon-cli)](https://crates.io/crates/galeon-cli)
 [![npm](https://img.shields.io/npm/v/@galeon/engine-ts)](https://www.npmjs.com/package/@galeon/engine-ts)
 [![license](https://img.shields.io/crates/l/galeon-engine)](https://github.com/galeon-engine/galeon/blob/master/LICENSE-AGPL)
 
@@ -66,6 +67,8 @@ the engine itself is shell-agnostic.
 - Fallback geometry for missing assets
 
 **CLI**
+- `cargo install --locked galeon-cli` is the supported way to install the
+  scaffolding/codegen CLI
 - `galeon new <name> --preset <preset>` scaffolds a preset-specific Galeon project
 - Presets: `server-authoritative`, `local-first`, `hybrid`
 - `local-first` is the only preset that currently scaffolds a runnable web
@@ -75,6 +78,17 @@ the engine itself is shell-agnostic.
   and client seams, not a ready-to-run shell
 - `galeon generate <ts|manifest|descriptors|routes>` emits project artifacts
 - `galeon routes` prints the effective route table for the current project
+
+## Install CLI
+
+```bash
+cargo install --locked galeon-cli
+galeon --help
+```
+
+`galeon-cli` moves in lockstep with the published Galeon engine release. An
+installed `galeon-cli` scaffolds the matching Galeon crate/package version for
+that release.
 
 ## CLI Getting Started
 
@@ -178,7 +192,7 @@ separate publish-only surface outside this checkout.
 
 ## Public Packages
 
-Galeon publishes **three Rust crates** to [crates.io](https://crates.io) and
+Galeon publishes **four Rust packages** to [crates.io](https://crates.io) and
 **three TypeScript packages** to [npm](https://www.npmjs.com).
 
 The TypeScript packages listed here are also checked into this repository under
@@ -192,6 +206,12 @@ The TypeScript packages listed here are also checked into this repository under
 | `galeon-engine` | [![crates.io](https://img.shields.io/crates/v/galeon-engine)](https://crates.io/crates/galeon-engine) | Core ECS, scheduler, protocol, data loading |
 | `galeon-engine-three-sync` | [![crates.io](https://img.shields.io/crates/v/galeon-engine-three-sync)](https://crates.io/crates/galeon-engine-three-sync) | WASM bridge (ECS snapshots &rarr; Three.js) |
 
+### CLI binary
+
+| Package | crates.io | Description |
+|---------|-----------|-------------|
+| `galeon-cli` | [![crates.io](https://img.shields.io/crates/v/galeon-cli)](https://crates.io/crates/galeon-cli) | Install surface for `galeon new`, `galeon generate`, and `galeon routes` |
+
 ### TypeScript packages
 
 | Package | npm | Description |
@@ -204,13 +224,13 @@ The TypeScript packages listed here are also checked into this repository under
 
 The following workspace members are internal and not published to any registry:
 
-- `galeon-cli` &mdash; CLI binary (deferred)
 - `galeon-protocol-rename-test`, `galeon-protocol-consumer-test` &mdash; integration test crates
 
 ## Versioning
 
-All Rust crates and TypeScript packages move in **lockstep** &mdash; every release
-bumps all six packages to the same version number.
+All four Rust packages and three TypeScript packages move in **lockstep**
+&mdash; every release bumps all seven published artifacts to the same version
+number.
 
 ### Pre-1.0 policy
 
@@ -236,6 +256,11 @@ galeon-engine = "0.1"
 "@galeon/engine-ts": "^0.1.0"
 ```
 
+```bash
+# Install the matching Galeon CLI release
+cargo install --locked galeon-cli
+```
+
 See [docs/guide/publishing.md](docs/guide/publishing.md) for the full release
 procedure and version bump checklist.
 
@@ -247,6 +272,8 @@ means for adopters:
 **What you can rely on today:**
 - The core engine crates (`galeon-engine`, `galeon-engine-macros`) are published,
   tested (350+ tests), and intended for evaluation and early adoption.
+- `galeon-cli` is published and supported for project scaffolding, protocol
+  artifact generation, and route inspection.
 - The ECS, scheduler, protocol layer, and WASM bridge are functional and
   cover real use cases.
 - Lockstep versioning means all packages stay in sync &mdash; no version matrix to

--- a/crates/galeon-cli/Cargo.toml
+++ b/crates/galeon-cli/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "galeon-cli"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+description = "Project scaffolding, code generation, and route inspection CLI for Galeon."
+keywords = ["galeon", "cli", "game-engine", "codegen"]
+categories = ["command-line-utilities", "game-development"]
 
 [[bin]]
 name = "galeon"

--- a/crates/galeon-cli/src/new.rs
+++ b/crates/galeon-cli/src/new.rs
@@ -281,6 +281,10 @@ mod template_dep_tests {
         let protocol = templates::protocol_cargo_toml("testgame");
         let domain = templates::domain_cargo_toml("testgame");
         let server = templates::server_cargo_toml("testgame");
+        let local_first_pkg = templates::local_first_package_json("testgame");
+        let local_first_client = templates::local_first_client_cargo_toml("testgame");
+        let galeon_version = templates::galeon_release_version();
+        let galeon_minor = templates::galeon_minor_version();
 
         for (label, content) in [
             ("protocol", &protocol),
@@ -288,7 +292,7 @@ mod template_dep_tests {
             ("server", &server),
         ] {
             assert!(
-                content.contains(r#"galeon-engine = "0.2.0""#),
+                content.contains(&format!(r#"galeon-engine = "{galeon_version}""#)),
                 "{label} template missing published crate dependency"
             );
             assert!(
@@ -296,5 +300,24 @@ mod template_dep_tests {
                 "{label} template still references git URL"
             );
         }
+
+        assert!(
+            local_first_client.contains(&format!(r#"galeon-engine = "{galeon_version}""#)),
+            "local-first client template missing engine dependency pinned to CLI release"
+        );
+        assert!(
+            local_first_client
+                .contains(&format!(r#"galeon-engine-three-sync = "{galeon_version}""#)),
+            "local-first client template missing three-sync dependency pinned to CLI release"
+        );
+        assert!(
+            local_first_pkg.contains(&format!(r#""@galeon/engine-ts": "^{galeon_version}""#)),
+            "local-first package.json missing engine-ts dependency pinned to CLI release"
+        );
+        assert!(
+            templates::galeon_toml("testgame", "local-first")
+                .contains(&format!(r#"engine = "{galeon_minor}""#)),
+            "galeon.toml should record the CLI major.minor engine line"
+        );
     }
 }

--- a/crates/galeon-cli/src/templates.rs
+++ b/crates/galeon-cli/src/templates.rs
@@ -1,5 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 
+pub(crate) fn galeon_release_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+pub(crate) fn galeon_minor_version() -> String {
+    let version = galeon_release_version();
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .expect("galeon-cli version must include a major semver component");
+    let minor = parts
+        .next()
+        .expect("galeon-cli version must include a minor semver component");
+    format!("{major}.{minor}")
+}
+
 /// Root `Cargo.toml` for the generated workspace.
 pub fn workspace_cargo_toml() -> String {
     r#"[workspace]
@@ -17,9 +33,10 @@ pub fn galeon_toml(name: &str, preset: &str) -> String {
     format!(
         r#"[project]
 name = "{name}"
-engine = "0.2"
+engine = "{}"
 preset = "{preset}"
-"#
+"#,
+        galeon_minor_version(),
     )
 }
 
@@ -36,8 +53,9 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-galeon-engine = "0.2.0"
-"#
+galeon-engine = "{}"
+"#,
+        galeon_release_version(),
     )
 }
 
@@ -63,9 +81,10 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-galeon-engine = "0.2.0"
+galeon-engine = "{}"
 {name}-protocol = {{ path = "../protocol" }}
-"#
+"#,
+        galeon_release_version(),
     )
 }
 
@@ -116,12 +135,13 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-galeon-engine = "0.2.0"
+galeon-engine = "{}"
 {name}-protocol = {{ path = "../protocol" }}
 {name}-domain = {{ path = "../domain" }}
 axum = "0.8"
 tokio = {{ version = "1", features = ["full"] }}
-"#
+"#,
+        galeon_release_version(),
     )
 }
 
@@ -207,7 +227,7 @@ pub fn local_first_package_json(name: &str) -> String {
     "check": "bun run wasm && bunx tsc --project client/tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@galeon/engine-ts": "^0.2.0",
+    "@galeon/engine-ts": "^__GALEON_VERSION__",
     "three": "^0.183.2"
   },
   "devDependencies": {
@@ -218,6 +238,7 @@ pub fn local_first_package_json(name: &str) -> String {
 }
 "#
         .replace("__NAME__", name)
+        .replace("__GALEON_VERSION__", galeon_release_version())
 }
 
 /// Starter `README.md` for the local-first preset.
@@ -534,11 +555,12 @@ edition.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-galeon-engine = "0.2.0"
-galeon-engine-three-sync = "0.2.0"
+galeon-engine = "{version}"
+galeon-engine-three-sync = "{version}"
 wasm-bindgen = "0.2"
 {name}-domain = {{ path = "../domain" }}
-"#
+"#,
+        version = galeon_release_version(),
     )
 }
 

--- a/docs/guide/cli-getting-started.md
+++ b/docs/guide/cli-getting-started.md
@@ -7,6 +7,23 @@ Galeon can scaffold projects, generate protocol artifacts, and inspect resolved
 routes. It does not yet expose a universal `galeon dev`, `galeon run`, or
 `galeon build` command.
 
+## Install The CLI
+
+```bash
+cargo install --locked galeon-cli
+galeon --help
+```
+
+`galeon-cli` moves in lockstep with the Galeon release it scaffolds. An
+installed `galeon-cli 0.2.x` emits a project wired to Galeon `0.2.x`, not a
+hardcoded older template version.
+
+For prereleases, install the exact version you want to evaluate:
+
+```bash
+cargo install --locked galeon-cli --version 0.2.0-alpha.1
+```
+
 ## Current Commands
 
 ```bash
@@ -45,6 +62,7 @@ you still add the runtime shell, transport glue, and app-specific boot flow.
 Use `local-first` when you want the shortest path to a first rendered frame:
 
 ```bash
+cargo install --locked galeon-cli
 galeon new my-game --preset local-first
 cd my-game
 bun install

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -4,7 +4,7 @@
 > to install and what stability to expect. This guide covers the release
 > procedure for maintainers.
 
-Galeon publishes **three Rust crates** to crates.io and **three TypeScript
+Galeon publishes **four Rust packages** to crates.io and **three TypeScript
 packages** to npm. Everything else in the workspace is internal.
 
 The npm packages in this guide are the checked-in workspace packages under
@@ -13,13 +13,19 @@ separate external-only package surface.
 
 ## Publish surfaces
 
-### Rust crates (crates.io)
+### Rust library crates (crates.io)
 
 | Crate | Package name | Order |
 |-------|-------------|-------|
 | Macros | `galeon-engine-macros` | 1 — publish first |
 | Core engine | `galeon-engine` | 2 — depends on macros |
 | Three.js sync | `galeon-engine-three-sync` | 3 — depends on engine |
+
+### CLI binary (crates.io)
+
+| Artifact | Package name | Order |
+|----------|--------------|-------|
+| CLI install surface | `galeon-cli` | 4 — publish after the libraries and npm starter deps |
 
 ### TypeScript packages (npm)
 
@@ -31,16 +37,15 @@ separate external-only package surface.
 
 ### Not published
 
-- `galeon-cli` — `publish = false` (deferred)
 - `galeon-protocol-rename-test`, `galeon-protocol-consumer-test` — `publish = false` (integration tests)
 
 ## Versioning
 
-All Rust crates and all TypeScript packages move in **lockstep**. The Rust
+All four Rust packages and all TypeScript packages move in **lockstep**. The Rust
 workspace version lives in `Cargo.toml` → `[workspace.package] version` and is
-inherited by publishable crates via `version.workspace = true`. npm package
-versions are kept in sync manually. Internal dependencies use exact pins
-(`=X.Y.Z`) to enforce lockstep.
+inherited by publishable crates via `version.workspace = true`, including
+`galeon-cli`. npm package versions are kept in sync manually. Internal
+dependencies use exact pins (`=X.Y.Z`) to enforce lockstep.
 
 ### Version bump checklist
 
@@ -51,8 +56,10 @@ bash scripts/bump-version.sh A.B.C
 ```
 
 This updates all 6 files (7 edits) after verifying the current versions are
-consistent, and rolls back if verification fails. It supports prerelease and
-build metadata tags (`0.2.0-alpha.1`, `0.2.0-alpha-1+build-7`).
+consistent, and rolls back if verification fails. `galeon-cli` inherits the
+workspace version automatically, so it does not need a separate version edit.
+The script supports prerelease and build metadata tags
+(`0.2.0-alpha.1`, `0.2.0-alpha-1+build-7`).
 
 The script edits these locations:
 
@@ -83,10 +90,17 @@ Cargo strips `path` for published tarballs.
 
 ```bash
 cargo publish -p galeon-engine-macros --dry-run
+cargo publish -p galeon-cli --dry-run
 ```
 
 `galeon-engine` and `galeon-engine-three-sync` dry-runs only pass after their
 dependencies exist on crates.io at the pinned version.
+
+To validate the supported installed-binary bootstrap flow from source, run:
+
+```bash
+bash tests/local-first-starter-smoke.sh
+```
 
 ### TypeScript
 
@@ -109,7 +123,8 @@ across these same checked-in workspace packages.
    - CI runs first (reused via `workflow_call`)
    - Crates publish in order with `cargo search` propagation polling
    - npm packages publish with skip-if-exists guards
-   - Post-publish verification installs from registries
+   - `galeon-cli` publishes after the starter's crate/npm dependencies exist
+   - Post-publish verification installs from registries, including the CLI starter flow
    - Evidence bundle uploaded as workflow artifact
    - GitHub Release created from the pushed tag, with prerelease tags marked as prereleases and the evidence markdown attached as a release asset
 
@@ -140,6 +155,12 @@ cd packages/engine-ts && npm publish --access public && cd ../..
 cd packages/shell    && npm publish --access public && cd ../..
 ```
 
+**CLI (after crates + npm packages):**
+
+```bash
+cargo publish -p galeon-cli
+```
+
 After the first publish, enable trusted publishing on npm for each package
 (link to the `galeon-engine/galeon` GitHub repo). Subsequent releases use
 OIDC provenance from GitHub Actions — no token needed.
@@ -161,10 +182,12 @@ OIDC provenance from GitHub Actions — no token needed.
 
 ## Consumer guidance
 
-Galeon is pre-1.0. All six packages move in lockstep &mdash; pick a minor version
-and pin to it. Read the [changelog](../../CHANGELOG.md) on each upgrade.
+Galeon is pre-1.0. All seven published artifacts move in lockstep &mdash; pick a
+minor version and pin to it. Read the [changelog](../../CHANGELOG.md) on each
+upgrade.
 
 - Core engine crates are published and intended for evaluation and early use.
+- `galeon-cli` is the supported install surface for scaffolding and codegen.
 - `@galeon/shell` is published but experimental &mdash; expect churn.
 - Prerelease tags (`alpha`, `beta`, `rc`) are published to both registries
   under the `alpha` npm dist-tag.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 #
-# bump-version.sh — Update all 6 lockstep version sources with rollback on failure.
+# bump-version.sh — Update the shared version sources for Galeon's 7 lockstep published artifacts.
 #
 # Usage: scripts/bump-version.sh X.Y.Z
 #
 # Validates semver format, checks current versions are consistent,
-# then updates all 7 locations across 6 files. Fails fast on any
-# inconsistency or missing file.
+# then updates all 7 versioned locations across 6 files. `galeon-cli`
+# inherits the workspace version, so it needs no separate bump file.
+# Fails fast on any inconsistency or missing file.
 
 set -euo pipefail
 
@@ -55,7 +56,7 @@ NEW_VERSION="${1:-}"
 if [[ -z "$NEW_VERSION" ]]; then
   echo "Usage: scripts/bump-version.sh X.Y.Z"
   echo ""
-  echo "Updates all 6 lockstep version sources (7 edits)."
+  echo "Updates Galeon's shared version sources (7 edits across 6 files)."
   exit 1
 fi
 

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -91,6 +91,11 @@ cleanup() {
 trap cleanup EXIT
 
 install_galeon_cli() {
+  if [[ -n "${GALEON_REQUIRE_PUBLISHED:-}" ]] && [[ -z "${GALEON_INSTALL_VERSION:-}" ]]; then
+    echo "GALEON_REQUIRE_PUBLISHED requires GALEON_INSTALL_VERSION to be set" >&2
+    return 1
+  fi
+
   if [[ -n "${GALEON_INSTALL_VERSION:-}" ]]; then
     local attempt
     for attempt in $(seq 1 20); do

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -4,9 +4,12 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMP_DIR="$(mktemp -d)"
+TMP_BASE="$REPO_ROOT/target/smoke-tmp"
+mkdir -p "$TMP_BASE"
+TMP_DIR="$(mktemp -d "$TMP_BASE/local-first-starter-smoke.XXXXXX")"
 PROJECT_NAME="starter-smoke"
 PROJECT_DIR="$TMP_DIR/$PROJECT_NAME"
+INSTALL_ROOT="$TMP_DIR/install-root"
 
 find_tool() {
   local name="$1"
@@ -39,9 +42,16 @@ normalize_path_for_tool() {
   local path="$1"
   local tool="$2"
 
-  if [[ "$tool" == *.exe ]] && command -v cygpath >/dev/null 2>&1; then
-    cygpath -w "$path"
-    return 0
+  if [[ "$tool" == *.exe ]]; then
+    if command -v cygpath >/dev/null 2>&1; then
+      cygpath -w "$path"
+      return 0
+    fi
+
+    if command -v wslpath >/dev/null 2>&1; then
+      wslpath -w "$path"
+      return 0
+    fi
   fi
 
   printf '%s\n' "$path"
@@ -49,18 +59,60 @@ normalize_path_for_tool() {
 
 CARGO_BIN="$(find_tool cargo)"
 BUN_BIN="$(find_tool bun)"
-REPO_MANIFEST="$(normalize_path_for_tool "$REPO_ROOT/Cargo.toml" "$CARGO_BIN")"
+INSTALL_ROOT_TOOL="$(normalize_path_for_tool "$INSTALL_ROOT" "$CARGO_BIN")"
+CLI_SOURCE_PATH="$(normalize_path_for_tool "$REPO_ROOT/crates/galeon-cli" "$CARGO_BIN")"
 
 cleanup() {
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
 
+install_galeon_cli() {
+  if [[ -n "${GALEON_INSTALL_VERSION:-}" ]]; then
+    local attempt
+    for attempt in $(seq 1 20); do
+      if "$CARGO_BIN" install --locked --root "$INSTALL_ROOT_TOOL" galeon-cli --version "$GALEON_INSTALL_VERSION"; then
+        return 0
+      fi
+      if [[ "$attempt" -eq 20 ]]; then
+        echo "failed to install galeon-cli ${GALEON_INSTALL_VERSION} from crates.io after ${attempt} attempts" >&2
+        return 1
+      fi
+      echo "galeon-cli ${GALEON_INSTALL_VERSION} not installable yet (attempt ${attempt}/20); retrying in 10s..."
+      sleep 10
+    done
+    return 1
+  fi
+
+  "$CARGO_BIN" install --locked --root "$INSTALL_ROOT_TOOL" --path "$CLI_SOURCE_PATH"
+}
+
+install_wasm_pack_if_missing() {
+  if find_tool wasm-pack >/dev/null 2>&1; then
+    return 0
+  fi
+
+  "$CARGO_BIN" install --locked --root "$INSTALL_ROOT_TOOL" wasm-pack
+}
+
+install_galeon_cli
+install_wasm_pack_if_missing
+
+export PATH="$INSTALL_ROOT/bin:$PATH"
+GALEON_BIN="$(find_tool galeon)"
+WASM_PACK_BIN="$(find_tool wasm-pack)"
+[[ -n "$GALEON_BIN" ]] || { echo "failed to locate installed galeon binary" >&2; exit 1; }
+[[ -n "$WASM_PACK_BIN" ]] || { echo "failed to locate wasm-pack" >&2; exit 1; }
+
+"$GALEON_BIN" --help >/dev/null
+
 pushd "$TMP_DIR" >/dev/null
-"$CARGO_BIN" run --manifest-path "$REPO_MANIFEST" -p galeon-cli -- new "$PROJECT_NAME" --preset local-first
+"$GALEON_BIN" new "$PROJECT_NAME" --preset local-first
 popd >/dev/null
 
 pushd "$PROJECT_DIR" >/dev/null
+"$GALEON_BIN" generate manifest >/dev/null
+test -f generated/manifest.json
 "$BUN_BIN" install
 "$BUN_BIN" run check
 "$BUN_BIN" run build

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -57,10 +57,33 @@ normalize_path_for_tool() {
   printf '%s\n' "$path"
 }
 
+normalize_file_dep_path() {
+  local path="$1"
+  local tool="$2"
+
+  if [[ "$tool" == *.exe ]]; then
+    if command -v cygpath >/dev/null 2>&1; then
+      cygpath -m "$path"
+      return 0
+    fi
+
+    if command -v wslpath >/dev/null 2>&1; then
+      wslpath -m "$path"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$path"
+}
+
 CARGO_BIN="$(find_tool cargo)"
 BUN_BIN="$(find_tool bun)"
 INSTALL_ROOT_TOOL="$(normalize_path_for_tool "$INSTALL_ROOT" "$CARGO_BIN")"
 CLI_SOURCE_PATH="$(normalize_path_for_tool "$REPO_ROOT/crates/galeon-cli" "$CARGO_BIN")"
+ENGINE_CRATE_DEP_PATH="$(normalize_file_dep_path "$REPO_ROOT/crates/engine" "$CARGO_BIN")"
+THREE_SYNC_CRATE_DEP_PATH="$(normalize_file_dep_path "$REPO_ROOT/crates/engine-three-sync" "$CARGO_BIN")"
+ENGINE_TS_PACKAGE_DEP_PATH="$(normalize_file_dep_path "$REPO_ROOT/packages/engine-ts" "$BUN_BIN")"
+RUNTIME_PACKAGE_DEP_PATH="$(normalize_file_dep_path "$REPO_ROOT/packages/runtime" "$BUN_BIN")"
 
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -95,6 +118,97 @@ install_wasm_pack_if_missing() {
   "$CARGO_BIN" install --locked --root "$INSTALL_ROOT_TOOL" wasm-pack
 }
 
+replace_line_in_file() {
+  local file="$1"
+  local prefix="$2"
+  local replacement="$3"
+
+  FILE="$file" PREFIX="$prefix" REPLACEMENT="$replacement" "$BUN_BIN" -e '
+const fs = require("node:fs");
+const file = process.env.FILE;
+const prefix = process.env.PREFIX;
+const replacement = process.env.REPLACEMENT;
+const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+let found = false;
+const updated = lines.map((line) => {
+  if (line.startsWith(prefix)) {
+    found = true;
+    return replacement;
+  }
+  return line;
+});
+if (!found) {
+  console.error(`expected line starting with "${prefix}" in ${file}`);
+  process.exit(1);
+}
+fs.writeFileSync(file, `${updated.join("\n").replace(/\n*$/, "\n")}`);
+'
+}
+
+assert_file_contains() {
+  local file="$1"
+  local snippet="$2"
+
+  FILE="$file" SNIPPET="$snippet" "$BUN_BIN" -e '
+const fs = require("node:fs");
+const file = process.env.FILE;
+const snippet = process.env.SNIPPET;
+if (!fs.readFileSync(file, "utf8").includes(snippet)) {
+  console.error(`expected ${file} to contain ${snippet}`);
+  process.exit(1);
+}
+'
+}
+
+configure_source_mode_scaffold() {
+  if [[ -n "${GALEON_INSTALL_VERSION:-}" ]]; then
+    return 0
+  fi
+
+  # Source-installed CLI validation should exercise current repo code, not
+  # unreleased registry versions that only exist after a publish step.
+  pushd "$REPO_ROOT" >/dev/null
+  "$BUN_BIN" install
+  "$BUN_BIN" x tsc --build packages/engine-ts/tsconfig.json
+  popd >/dev/null
+
+  replace_line_in_file \
+    "$PROJECT_DIR/crates/protocol/Cargo.toml" \
+    "galeon-engine = " \
+    "galeon-engine = { path = \"$ENGINE_CRATE_DEP_PATH\" }"
+  replace_line_in_file \
+    "$PROJECT_DIR/crates/domain/Cargo.toml" \
+    "galeon-engine = " \
+    "galeon-engine = { path = \"$ENGINE_CRATE_DEP_PATH\" }"
+  replace_line_in_file \
+    "$PROJECT_DIR/crates/client/Cargo.toml" \
+    "galeon-engine = " \
+    "galeon-engine = { path = \"$ENGINE_CRATE_DEP_PATH\" }"
+  replace_line_in_file \
+    "$PROJECT_DIR/crates/client/Cargo.toml" \
+    "galeon-engine-three-sync = " \
+    "galeon-engine-three-sync = { path = \"$THREE_SYNC_CRATE_DEP_PATH\" }"
+
+  PACKAGE_JSON="$PROJECT_DIR/package.json" \
+  ENGINE_TS_FILE_DEP="file:$ENGINE_TS_PACKAGE_DEP_PATH" \
+  RUNTIME_FILE_DEP="file:$RUNTIME_PACKAGE_DEP_PATH" \
+  "$BUN_BIN" -e '
+const fs = require("node:fs");
+const file = process.env.PACKAGE_JSON;
+const engineTs = process.env.ENGINE_TS_FILE_DEP;
+const runtime = process.env.RUNTIME_FILE_DEP;
+const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+pkg.dependencies["@galeon/engine-ts"] = engineTs;
+pkg.dependencies["@galeon/runtime"] = runtime;
+fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+'
+
+  assert_file_contains "$PROJECT_DIR/crates/protocol/Cargo.toml" 'galeon-engine = { path = "'
+  assert_file_contains "$PROJECT_DIR/crates/client/Cargo.toml" 'galeon-engine-three-sync = { path = "'
+  assert_file_contains "$PROJECT_DIR/package.json" '"@galeon/engine-ts": "file:'
+  assert_file_contains "$PROJECT_DIR/package.json" '"@galeon/runtime": "file:'
+}
+
 install_galeon_cli
 install_wasm_pack_if_missing
 
@@ -109,6 +223,8 @@ WASM_PACK_BIN="$(find_tool wasm-pack)"
 pushd "$TMP_DIR" >/dev/null
 "$GALEON_BIN" new "$PROJECT_NAME" --preset local-first
 popd >/dev/null
+
+configure_source_mode_scaffold
 
 pushd "$PROJECT_DIR" >/dev/null
 "$GALEON_BIN" generate manifest >/dev/null


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 197
branch: issue/197-publish-galeon-cli
status: resolved
updated_at: 2026-04-21T16:35:47Z
-->

## Summary

This PR makes galeon-cli a supported public install surface instead of a source-only tool. The CLI now inherits the workspace release version, scaffolds matching Galeon crate/package versions from the installed binary, and the release pipeline now publishes and verifies the CLI explicitly.

Closes #197

## Journey Timeline

### Initial Plan
Ship galeon-cli as a real crates.io install surface without widening scope into Homebrew, npm, or standalone installer packaging, and prove the installed-binary bootstrap path for a fresh local-first starter.

### What We Discovered
- The existing #197 work lived as an uncommitted diff in a dedicated worktree on top of current master, so the first step was turning it into a real issue-branch commit before PR creation.
- The publish/install verification path warned that Cargo.lock pinned yanked astrand 2.4.0 through 	empfile, so the branch refreshes that lockfile entry to 2.4.1 before shipping the supported cargo install --locked flow.

### Implementation Issues
- The contextplus static-analysis MCP wrapper failed with a transport-closed error during verification, so verification fell back to direct cargo and un commands. No repo change was needed.
- Windows and WSL path normalization in the starter smoke flow had to account for installed galeon.exe; the smoke script now normalizes install paths for .exe tools and installs both galeon-cli and wasm-pack into an isolated root.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| CLI support contract | cargo install --locked galeon-cli | Matches the documented bootstrap path and keeps the first supported install surface inside Cargo. |
| Template version source | Derive crate/package versions from CARGO_PKG_VERSION and major.minor | An installed CLI should scaffold the matching Galeon release instead of drifting behind with hardcoded versions. |
| Release verification shape | Publish the CLI after the library and npm starter dependencies, then rerun the installed-binary starter smoke flow | The CLI scaffold depends on artifacts that must already exist on crates.io and npm. |
| Lockfile hygiene | Refresh astrand to 2.4.1 | Avoid shipping a fresh --locked install surface with a known yanked transitive warning. |

### Changes Made

**Commits:**
- 268bb64 feat(#197): publish galeon-cli install surface

## Testing

**Verification profile:** local branch verification

- [x] cargo fmt --check
- [x] un install
- [x] un run check
- [x] cargo test -p galeon-cli
- [x] cargo test --workspace
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync
- [x] cargo publish -p galeon-cli --dry-run --allow-dirty
- [x] ash tests/local-first-starter-smoke.sh
- [x] All existing tests pass
- [x] Self-audit: implementation reviewed for redundancy, dead code, and simplification opportunities

**Verification summary:** The installed-binary starter path is now proven from galeon --help through scaffold, manifest generation, Bun type-check/build, and wasm-pack build. Post-refresh publish/install verification no longer warns about yanked astrand 2.4.0.

## Stacked PRs / Related

- #190
- #191
- #192

## Knowledge for Future Reference

galeon-cli now ships in lockstep with the engine release and templates depend on the installed CLI version at generation time. Any future starter or publishing change needs to preserve the installed-binary smoke contract and keep elease.yml, 	ests/local-first-starter-smoke.sh, and the docs in sync.

Review gate: requires cross-model review before merge.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
