### PR TITLE
fix(#190): validate scaffold project names before file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **CLI scaffold rejects invalid project names before writing files (#190)** —
+  `galeon new` now enforces a cross-surface-safe project-name grammar:
+  lowercase ASCII letters, digits, and single hyphens only, starting with a
+  letter and excluding reserved Windows filenames.
+
 - **TypeScript workspace `bun run check` (#194)** — Declared workspace type
   surface intentionally in `tsconfig.base.json`: added `DOM` and
   `DOM.Iterable` to `lib` (for `console.warn` in `renderer-cache.ts` and the

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ the engine itself is shell-agnostic.
 - `cargo install --locked galeon-cli` is the supported way to install the
   scaffolding/codegen CLI
 - `galeon new <name> --preset <preset>` scaffolds a preset-specific Galeon project
+  and requires `name` to use lowercase letters, digits, and single hyphens
 - Presets: `server-authoritative`, `local-first`, `hybrid`
 - `local-first` is the only preset that currently scaffolds a runnable web
   starter with `bun run dev` / `bun run build`; see

--- a/crates/galeon-cli/src/main.rs
+++ b/crates/galeon-cli/src/main.rs
@@ -18,7 +18,7 @@ struct Cli {
 enum CliCommand {
     /// Scaffold a new Galeon game project
     New {
-        /// Project name
+        /// Project name (lowercase letters, numbers, and single hyphens)
         name: String,
         /// Project preset
         #[arg(long, default_value = "server-authoritative")]

--- a/crates/galeon-cli/src/new.rs
+++ b/crates/galeon-cli/src/new.rs
@@ -7,11 +7,18 @@ use std::path::Path;
 use crate::Preset;
 use crate::templates;
 
+const WINDOWS_RESERVED_NAMES: &[&str] = &[
+    "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+    "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
 /// Scaffold a new Galeon game project at `<base>/<name>/`.
 ///
 /// `base` is the directory in which the project folder is created.
 /// Pass `Path::new(".")` (or the current directory) for the typical CLI case.
 pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Error> {
+    validate_project_name(name)?;
+
     let root = base.join(name);
 
     let preset_str = match preset {
@@ -145,6 +152,75 @@ pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Erro
     Ok(())
 }
 
+fn validate_project_name(name: &str) -> Result<(), io::Error> {
+    if name.is_empty() {
+        return Err(invalid_project_name(
+            name,
+            "project names must start with a lowercase ASCII letter",
+        ));
+    }
+
+    let first = name
+        .chars()
+        .next()
+        .expect("empty project name handled above");
+    if !first.is_ascii_lowercase() {
+        return Err(invalid_project_name(
+            name,
+            "project names must start with a lowercase ASCII letter",
+        ));
+    }
+
+    let last = name
+        .chars()
+        .last()
+        .expect("empty project name handled above");
+    if !last.is_ascii_lowercase() && !last.is_ascii_digit() {
+        return Err(invalid_project_name(
+            name,
+            "project names must end with a lowercase ASCII letter or digit",
+        ));
+    }
+
+    let mut prev_hyphen = false;
+    for ch in name.chars() {
+        match ch {
+            'a'..='z' | '0'..='9' => prev_hyphen = false,
+            '-' => {
+                if prev_hyphen {
+                    return Err(invalid_project_name(
+                        name,
+                        "project names may only use single hyphens between segments",
+                    ));
+                }
+                prev_hyphen = true;
+            }
+            _ => {
+                return Err(invalid_project_name(
+                    name,
+                    "project names may only use lowercase ASCII letters, digits, and hyphens",
+                ));
+            }
+        }
+    }
+
+    if WINDOWS_RESERVED_NAMES.contains(&name) {
+        return Err(invalid_project_name(
+            name,
+            "project names cannot use reserved Windows filenames like `aux` or `con`",
+        ));
+    }
+
+    Ok(())
+}
+
+fn invalid_project_name(name: &str, reason: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("invalid project name `{name}`: {reason}. Examples: `my-game`, `game2`, `game-2`"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -269,6 +345,43 @@ mod tests {
             content.contains("preset = \"server-authoritative\""),
             "galeon.toml missing preset"
         );
+    }
+
+    #[test]
+    fn test_accepts_lowercase_kebab_case_project_names() {
+        let (_tmp, root) = run_scaffold("my-game-2", Preset::LocalFirst);
+
+        assert_file(&root, "package.json");
+        assert_file(&root, "crates/domain/Cargo.toml");
+        assert_file(&root, "crates/client/Cargo.toml");
+    }
+
+    #[test]
+    fn test_rejects_invalid_project_names_before_writing_files() {
+        let cases = [
+            ("", "start with a lowercase ASCII letter"),
+            ("123game", "start with a lowercase ASCII letter"),
+            ("Game", "start with a lowercase ASCII letter"),
+            ("game name", "lowercase ASCII letters, digits, and hyphens"),
+            ("game_name", "lowercase ASCII letters, digits, and hyphens"),
+            ("game--name", "single hyphens between segments"),
+            ("game-", "end with a lowercase ASCII letter or digit"),
+            ("aux", "reserved Windows filenames"),
+        ];
+
+        for (name, expected_message) in cases {
+            let tmp = TempDir::new().unwrap();
+            let err = scaffold(tmp.path(), name, &Preset::LocalFirst).unwrap_err();
+
+            assert!(
+                err.to_string().contains(expected_message),
+                "unexpected error for `{name}`: {err}"
+            );
+            assert!(
+                fs::read_dir(tmp.path()).unwrap().next().is_none(),
+                "scaffold wrote files for invalid project name `{name}`"
+            );
+        }
     }
 }
 

--- a/docs/guide/cli-getting-started.md
+++ b/docs/guide/cli-getting-started.md
@@ -41,6 +41,10 @@ galeon routes
   under `generated/` by default
 - `galeon routes` prints the effective route table for the current project
 
+Project names for `galeon new` are intentionally strict: use lowercase ASCII
+letters, digits, and single hyphens, start with a letter, and avoid reserved
+Windows names such as `aux` and `con`. Example: `my-game-2`.
+
 `galeon generate` and `galeon routes` both walk up from the current working
 directory until they find `galeon.toml`, so you can run them from the project
 root or from a nested crate directory.


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 190
branch: issue/190-validate-project-names
status: resolved
updated_at: 2026-04-22T12:30:00Z
review_status: approved
updated_by: claude/opus-4.7 (claude-code)
edit_kind: amendment
-->

## Summary

This PR makes galeon new reject project names that cannot safely map across the generated scaffold surfaces. The CLI now validates names before it writes any files, enforces a lowercase ASCII letter/digit/single-hyphen grammar, blocks reserved Windows filenames, adds regression coverage, and documents the contract in the public CLI docs.

Closes #190

## Review Status

- **Current state:** approved
- **Last reviewed by:** claude/opus-4.7 (claude-code)
- **Last reviewed at:** 2026-04-22T12:30:00Z
- **Reviewed commit:** 6fb6f72
- **Source artifact:** https://github.com/galeon-engine/galeon/pull/200#issuecomment-4295868697
- **Needs re-review since:** —

## Journey Timeline

### Initial Plan
Define one explicit scaffold-name grammar that is safe for the generated Cargo package names, derived Rust crate identifiers, and local-first JavaScript package metadata, then enforce it at the CLI boundary instead of allowing bad names to fail later inside generated projects.

### What We Discovered
- The scaffold path was still using the raw CLI name everywhere: project directory, galeon.toml, generated Cargo package names, the derived Rust crate import path, and the local-first root package.json name.
- Galeon's template topology means the raw project name itself is not used as a Rust crate name; the real cross-surface hazards are names that start with a digit, contain spaces or punctuation, or collide with Windows reserved path names.
- The shortest durable contract is stricter than Cargo's broad package parser: lowercase ASCII letters, digits, and single hyphens only, starting with a letter and ending with an alphanumeric character, with no normalization step.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Name contract | Lowercase ASCII letters, digits, and single hyphens; must start with a letter; must end with a letter or digit | Keeps generated Cargo package names, Rust crate identifiers, and JS package metadata in a predictable grammar without hidden normalization |
| Normalization policy | Reject invalid input instead of rewriting it | Avoids surprising users by silently changing project identity across generated files |
| Windows handling | Reject reserved Windows filenames like `aux`, `con`, and `nul` | The scaffold creates the project directory immediately, so cross-platform path safety matters before any generated code exists |
| User-facing guidance | Document the contract in CLI help, README, and docs/guide/cli-getting-started.md | The validation is public CLI behavior, not just an internal generator constraint |

### Changes Made

**Commits:**
- 6fb6f72 fix(#190): validate scaffold project names before file writes

## Testing

- [x] cargo test -p galeon-cli
- [x] cargo fmt --check
- [x] cargo clippy -p galeon-cli -- -D warnings
- [x] Invalid-name repro: `cargo run --manifest-path <repo>/Cargo.toml -p galeon-cli -- new 'game name'` exits 1 and creates no project directory
- [x] Regression coverage for valid kebab-case names and invalid names (empty, leading digit, uppercase, spaces, underscores, repeated hyphens, trailing hyphen, reserved Windows name)
- [x] Self-audit: implementation reviewed for unnecessary normalization or hidden rename behavior

## Knowledge for Future Reference

The validator is intentionally narrow because the scaffold fans the same project name into multiple generated surfaces. If Galeon ever adds scoped npm names, explicit Cargo package overrides, or a separate display-name concept, that should be a deliberate expansion of the contract rather than a silent relaxation of this shared identifier path.

## Review Gate

Independent cross-model review is required before merge per **shiplog**.

Cross-model approval recorded above (Review Status). Gate satisfied.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
Last-code-by: openai/gpt-5.4 (codex, effort: high)
Updated-by: claude/opus-4.7 (claude-code)
Edit-kind: amendment
Edit-note: Added Review Status snapshot after cross-model approval; escaped `aux`/`con`/`nul` in the Key Decisions table so the row renders correctly.
*Captain's log — PR timeline by **shiplog***
