### PR TITLE
release(#201): prepare 0.3.0 metadata and docs [stack: #190]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to verify (e.g. 0.2.0). Skips publish, runs verification only.'
+        description: 'Version to verify (e.g. 0.3.0). Skips publish, runs verification only.'
         required: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **CLI scaffold rejects invalid project names before writing files (#190)** —
+  `galeon new` now enforces a cross-surface-safe project-name grammar:
+  lowercase ASCII letters, digits, and single hyphens only, starting with a
+  letter and excluding reserved Windows filenames.
+
 - **TypeScript workspace `bun run check` (#194)** — Declared workspace type
   surface intentionally in `tsconfig.base.json`: added `DOM` and
   `DOM.Iterable` to `lib` (for `console.warn` in `renderer-cache.ts` and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0]
+
 ### Added
 
 - **Published `galeon-cli` install surface (#197)** — `galeon-cli` is now part

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "galeon-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "serde",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "galeon-engine-macros",
  "inventory",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-three-sync"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "galeon-engine",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "AGPL-3.0-only OR LicenseRef-Commercial"
 repository = "https://github.com/galeon-engine/galeon"

--- a/README.md
+++ b/README.md
@@ -238,23 +238,23 @@ number.
 Galeon follows [Semantic Versioning 2.0.0](https://semver.org/). During the
 pre-1.0 phase:
 
-- **Minor bumps** (`0.1 &rarr; 0.2`) may contain breaking API changes.
-- **Patch bumps** (`0.1.0 &rarr; 0.1.1`) are backward-compatible bug fixes and
+- **Minor bumps** (`0.2 &rarr; 0.3`) may contain breaking API changes.
+- **Patch bumps** (`0.3.0 &rarr; 0.3.1`) are backward-compatible bug fixes and
   additions.
-- **Prerelease tags** (`0.2.0-alpha.1`, `0.2.0-beta.1`, `0.2.0-rc.1`) are
+- **Prerelease tags** (`0.3.0-alpha.1`, `0.3.0-beta.1`, `0.3.0-rc.1`) are
   published to crates.io and npm under the `alpha` dist-tag. Use these
   preview upcoming releases.
 
 ### How to depend on Galeon
 
 ```toml
-# In your Cargo.toml — matches any 0.1.x release
-galeon-engine = "0.1"
+# In your Cargo.toml — matches any 0.3.x release
+galeon-engine = "0.3"
 ```
 
 ```json
-// In your package.json — matches any 0.1.x release
-"@galeon/engine-ts": "^0.1.0"
+// In your package.json — matches any 0.3.x release
+"@galeon/engine-ts": "^0.3.0"
 ```
 
 ```bash
@@ -286,7 +286,7 @@ means for adopters:
 - CLI commands and codegen output formats are still evolving.
 
 **How to upgrade safely:**
-- Pin to a specific minor range (e.g., `"0.1"` in Cargo, `"^0.1.0"` in npm).
+- Pin to a specific minor range (e.g., `"0.3"` in Cargo, `"^0.3.0"` in npm).
 - Read the [changelog](CHANGELOG.md) before upgrading &mdash; breaking changes are
   always documented.
 - Prerelease tags (`alpha`, `beta`, `rc`) let you test upcoming versions before

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ the engine itself is shell-agnostic.
 - `cargo install --locked galeon-cli` is the supported way to install the
   scaffolding/codegen CLI
 - `galeon new <name> --preset <preset>` scaffolds a preset-specific Galeon project
+  and requires `name` to use lowercase letters, digits, and single hyphens
 - Presets: `server-authoritative`, `local-first`, `hybrid`
 - `local-first` is the only preset that currently scaffolds a runnable web
   starter with `bun run dev` / `bun run build`; see

--- a/crates/engine-three-sync/Cargo.toml
+++ b/crates/engine-three-sync/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-development", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-galeon-engine = { path = "../engine", version = "=0.2.0" }
+galeon-engine = { path = "../engine", version = "=0.3.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["galeon", "ecs", "game-engine", "entity"]
 categories = ["game-development"]
 
 [dependencies]
-galeon-engine-macros = { path = "../engine-macros", version = "=0.2.0" }
+galeon-engine-macros = { path = "../engine-macros", version = "=0.3.0" }
 inventory = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/galeon-cli/src/main.rs
+++ b/crates/galeon-cli/src/main.rs
@@ -18,7 +18,7 @@ struct Cli {
 enum CliCommand {
     /// Scaffold a new Galeon game project
     New {
-        /// Project name
+        /// Project name (lowercase letters, numbers, and single hyphens)
         name: String,
         /// Project preset
         #[arg(long, default_value = "server-authoritative")]

--- a/crates/galeon-cli/src/new.rs
+++ b/crates/galeon-cli/src/new.rs
@@ -7,11 +7,18 @@ use std::path::Path;
 use crate::Preset;
 use crate::templates;
 
+const WINDOWS_RESERVED_NAMES: &[&str] = &[
+    "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+    "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
 /// Scaffold a new Galeon game project at `<base>/<name>/`.
 ///
 /// `base` is the directory in which the project folder is created.
 /// Pass `Path::new(".")` (or the current directory) for the typical CLI case.
 pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Error> {
+    validate_project_name(name)?;
+
     let root = base.join(name);
 
     let preset_str = match preset {
@@ -145,6 +152,75 @@ pub fn scaffold(base: &Path, name: &str, preset: &Preset) -> Result<(), io::Erro
     Ok(())
 }
 
+fn validate_project_name(name: &str) -> Result<(), io::Error> {
+    if name.is_empty() {
+        return Err(invalid_project_name(
+            name,
+            "project names must start with a lowercase ASCII letter",
+        ));
+    }
+
+    let first = name
+        .chars()
+        .next()
+        .expect("empty project name handled above");
+    if !first.is_ascii_lowercase() {
+        return Err(invalid_project_name(
+            name,
+            "project names must start with a lowercase ASCII letter",
+        ));
+    }
+
+    let last = name
+        .chars()
+        .last()
+        .expect("empty project name handled above");
+    if !last.is_ascii_lowercase() && !last.is_ascii_digit() {
+        return Err(invalid_project_name(
+            name,
+            "project names must end with a lowercase ASCII letter or digit",
+        ));
+    }
+
+    let mut prev_hyphen = false;
+    for ch in name.chars() {
+        match ch {
+            'a'..='z' | '0'..='9' => prev_hyphen = false,
+            '-' => {
+                if prev_hyphen {
+                    return Err(invalid_project_name(
+                        name,
+                        "project names may only use single hyphens between segments",
+                    ));
+                }
+                prev_hyphen = true;
+            }
+            _ => {
+                return Err(invalid_project_name(
+                    name,
+                    "project names may only use lowercase ASCII letters, digits, and hyphens",
+                ));
+            }
+        }
+    }
+
+    if WINDOWS_RESERVED_NAMES.contains(&name) {
+        return Err(invalid_project_name(
+            name,
+            "project names cannot use reserved Windows filenames like `aux` or `con`",
+        ));
+    }
+
+    Ok(())
+}
+
+fn invalid_project_name(name: &str, reason: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("invalid project name `{name}`: {reason}. Examples: `my-game`, `game2`, `game-2`"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -269,6 +345,43 @@ mod tests {
             content.contains("preset = \"server-authoritative\""),
             "galeon.toml missing preset"
         );
+    }
+
+    #[test]
+    fn test_accepts_lowercase_kebab_case_project_names() {
+        let (_tmp, root) = run_scaffold("my-game-2", Preset::LocalFirst);
+
+        assert_file(&root, "package.json");
+        assert_file(&root, "crates/domain/Cargo.toml");
+        assert_file(&root, "crates/client/Cargo.toml");
+    }
+
+    #[test]
+    fn test_rejects_invalid_project_names_before_writing_files() {
+        let cases = [
+            ("", "start with a lowercase ASCII letter"),
+            ("123game", "start with a lowercase ASCII letter"),
+            ("Game", "start with a lowercase ASCII letter"),
+            ("game name", "lowercase ASCII letters, digits, and hyphens"),
+            ("game_name", "lowercase ASCII letters, digits, and hyphens"),
+            ("game--name", "single hyphens between segments"),
+            ("game-", "end with a lowercase ASCII letter or digit"),
+            ("aux", "reserved Windows filenames"),
+        ];
+
+        for (name, expected_message) in cases {
+            let tmp = TempDir::new().unwrap();
+            let err = scaffold(tmp.path(), name, &Preset::LocalFirst).unwrap_err();
+
+            assert!(
+                err.to_string().contains(expected_message),
+                "unexpected error for `{name}`: {err}"
+            );
+            assert!(
+                fs::read_dir(tmp.path()).unwrap().next().is_none(),
+                "scaffold wrote files for invalid project name `{name}`"
+            );
+        }
     }
 }
 

--- a/docs/guide/cli-getting-started.md
+++ b/docs/guide/cli-getting-started.md
@@ -15,13 +15,13 @@ galeon --help
 ```
 
 `galeon-cli` moves in lockstep with the Galeon release it scaffolds. An
-installed `galeon-cli 0.2.x` emits a project wired to Galeon `0.2.x`, not a
+installed `galeon-cli X.Y.x` emits a project wired to Galeon `X.Y.x`, not a
 hardcoded older template version.
 
 For prereleases, install the exact version you want to evaluate:
 
 ```bash
-cargo install --locked galeon-cli --version 0.2.0-alpha.1
+cargo install --locked galeon-cli --version 0.3.0-alpha.1
 ```
 
 ## Current Commands

--- a/docs/guide/cli-getting-started.md
+++ b/docs/guide/cli-getting-started.md
@@ -41,6 +41,10 @@ galeon routes
   under `generated/` by default
 - `galeon routes` prints the effective route table for the current project
 
+Project names for `galeon new` are intentionally strict: use lowercase ASCII
+letters, digits, and single hyphens, start with a letter, and avoid reserved
+Windows names such as `aux` and `con`. Example: `my-game-2`.
+
 `galeon generate` and `galeon routes` both walk up from the current working
 directory until they find `galeon.toml`, so you can run them from the project
 root or from a nested crate directory.

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -59,7 +59,7 @@ This updates all 6 files (7 edits) after verifying the current versions are
 consistent, and rolls back if verification fails. `galeon-cli` inherits the
 workspace version automatically, so it does not need a separate version edit.
 The script supports prerelease and build metadata tags
-(`0.2.0-alpha.1`, `0.2.0-alpha-1+build-7`).
+(`0.3.0-alpha.1`, `0.3.0-alpha-1+build-7`).
 
 The script edits these locations:
 
@@ -79,7 +79,7 @@ After running, manually update the changelog:
 Workspace crates use **path + pinned version**:
 
 ```toml
-galeon-engine-macros = { path = "../engine-macros", version = "=0.1.0" }
+galeon-engine-macros = { path = "../engine-macros", version = "=0.3.0" }
 ```
 
 Cargo strips `path` for published tarballs.

--- a/packages/engine-ts/package.json
+++ b/packages/engine-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/engine-ts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Galeon Engine TypeScript layer — Three.js sync consumer for WASM extraction snapshots",
   "type": "module",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/runtime": "=0.2.0",
+    "@galeon/runtime": "=0.3.0",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/runtime",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Galeon Engine runtime — thin JS↔WASM invoke/events bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/shell",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Galeon Engine editor shell — Godot-style Solid.js panel UI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 201
branch: issue/201-prepare-0-3-0-release
status: resolved
updated_at: 2026-04-22T13:10:00Z
review_status: needs-rereview
updated_by: openai/gpt-5.4 (codex, effort: high)
edit_kind: amendment
-->

## Summary

This stacked PR prepares Galeon's `0.3.0` release metadata and keeps the unreleased starter smoke path valid before publish. It bumps the lockstep published versions from `0.2.0` to `0.3.0`, updates `Cargo.lock`, cuts the `0.3.0` changelog section, refreshes the maintained CLI/release docs, and fixes source-mode starter smoke so Bun stays on local workspace packages instead of trying to fetch unpublished `0.3.0` npm artifacts.

Closes #201

## Review Status

- **Current state:** needs-rereview
- **Last reviewed by:** claude/opus-4.7 (claude-code)
- **Last reviewed at:** 2026-04-22T12:30:00Z
- **Reviewed commit:** `353b721`
- **Source artifact:** https://github.com/galeon-engine/galeon/pull/202#issuecomment-4295869147
- **Needs re-review since:** `f673350`

## Journey Timeline

### Initial Plan
Stage the release metadata separately from the code-bearing #190 bugfix so review can focus on the version/changelog/docs delta while still including the pending pre-release fix in the stacked branch.

### What We Discovered
- `scripts/bump-version.sh` already covers the seven lockstep version edits, but `Cargo.lock` still needs to move with the workspace version once the release-prep branch is exercised.
- The changelog was already complete for the April 6–21 merge train, so cutting `0.3.0` was a structure change, not a content rewrite.
- A few maintained docs/examples were still anchored to earlier lines: the CLI guide still said `0.2.x`, README dependency examples still used `0.1`, and the release workflow / publishing guide examples still illustrated `0.2.0` prereleases.
- Release-prep CI exposed a hidden source-mode dependency gap: the generated starter's direct `file:` deps were local, but Bun still tried to satisfy `@galeon/engine-ts`'s exact `@galeon/runtime = "=0.3.0"` subdependency from npm before publish.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Release prep isolation | Stack this branch on #200 / `issue/190-validate-project-names` | Keeps the version/docs review separate while ensuring `0.3.0` includes the pending pre-release bugfix |
| Version bump mechanism | Use `scripts/bump-version.sh 0.3.0` instead of hand-editing | Reuses the repo's audited lockstep workflow and catches version-drift mistakes automatically |
| Changelog shape | Leave `## [Unreleased]` empty and move the full current train under `## [0.3.0]` | Produces a clean release cut without mixing future backlog work into the shipped section |
| Doc examples | Update maintained examples to `0.3`/`0.3.0` or generic `X.Y.x` wording | Removes stale release guidance without baking in more unnecessary line-specific assumptions than needed |
| Source-mode starter contract | Override `@galeon/runtime` locally during pre-publish smoke | PR/tag CI must validate unreleased starter versions against local workspace packages, while post-publish verification remains registry-backed |

### Changes Made

**Commits:**
- `353b721` `release(#201): prepare 0.3.0 metadata and docs`
- `f673350` `fix(#201): keep source-mode starter smoke off unpublished npm deps`

## Testing

- [x] `bash scripts/bump-version.sh 0.3.0`
- [x] `cargo test -p galeon-cli`
- [x] `bun install`
- [x] `bun run check`
- [x] `cargo publish -p galeon-cli --dry-run --allow-dirty`
- [x] Targeted repro: scaffolded a local-first starter, rewrote it to source-mode `file:` deps plus the new Bun override, and confirmed `bun install` succeeded without trying to fetch `@galeon/runtime@=0.3.0` from npm
- [x] Self-audit: checked for stale maintained release examples after the bump and for hidden registry resolution in source-mode starter validation

## Stacked PRs / Related

- #200

## Knowledge for Future Reference

The scripted bump is necessary but not sufficient for a clean release branch. `Cargo.lock` moves once the new workspace version is built, the maintainer-facing docs/examples need a quick sweep, and source-mode starter validation has to override exact transitive npm pins locally or CI deadlocks on artifacts that only exist after publish.

## Review Gate

Independent cross-model review is required before merge per **shiplog**.

The earlier approval on commit `353b721` is now stale because code changed in `f673350`. This PR needs a fresh cross-model review.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
Last-code-by: openai/gpt-5.4 (codex, effort: high)
Updated-by: claude/opus-4.7 (claude-code)
Updated-by: openai/gpt-5.4 (codex, effort: high)
Edit-kind: amendment
Edit-note: Added the source-mode starter smoke fix after CI exposed the unpublished npm runtime dependency, and marked the prior approval stale pending re-review.
*Captain's log — PR timeline by **shiplog***