### PR TITLE
fix(#203): keep source-mode starter smoke off unpublished npm deps

### DIFF
--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -205,7 +205,7 @@ const runtime = process.env.RUNTIME_FILE_DEP;
 const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
 pkg.dependencies["@galeon/engine-ts"] = engineTs;
 pkg.dependencies["@galeon/runtime"] = runtime;
-// Bun still resolves engine-ts's exact @galeon/runtime subdependency from the
+// Bun still resolves the exact @galeon/runtime subdependency from engine-ts via
 // registry unless the generated starter overrides it locally in source mode.
 pkg.overrides ??= {};
 pkg.overrides["@galeon/runtime"] = runtime;

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -205,6 +205,10 @@ const runtime = process.env.RUNTIME_FILE_DEP;
 const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
 pkg.dependencies["@galeon/engine-ts"] = engineTs;
 pkg.dependencies["@galeon/runtime"] = runtime;
+// Bun still resolves engine-ts's exact @galeon/runtime subdependency from the
+// registry unless the generated starter overrides it locally in source mode.
+pkg.overrides ??= {};
+pkg.overrides["@galeon/runtime"] = runtime;
 fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
 '
 
@@ -212,6 +216,7 @@ fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
   assert_file_contains "$PROJECT_DIR/crates/client/Cargo.toml" 'galeon-engine-three-sync = { path = "'
   assert_file_contains "$PROJECT_DIR/package.json" '"@galeon/engine-ts": "file:'
   assert_file_contains "$PROJECT_DIR/package.json" '"@galeon/runtime": "file:'
+  assert_file_contains "$PROJECT_DIR/package.json" '"overrides": {'
 }
 
 install_galeon_cli


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 203
branch: issue/203-starter-smoke-runtime-override
status: resolved
updated_at: 2026-04-22T13:55:00Z
-->

## Summary

This PR fixes the post-merge CI/CD regression introduced by the 0.3.0 release-prep branch. Source-mode starter smoke now overrides @galeon/runtime to the local workspace package, so Bun stops trying to resolve the unpublished exact runtime version from npm before the release workflow has published it.

Closes #203

## Journey Timeline

### Initial Plan
Patch only the pre-publish source-mode smoke path on top of current master, then re-run the failing CI-equivalent repro before opening a follow-up PR against master.

### What We Discovered
- The original failure on #202 moved to master and the 0.3.0 tag gate as soon as the release-prep PR merged.
- The generated starter already rewrote its direct @galeon/engine-ts and @galeon/runtime dependencies to local ile: paths in source mode.
- Bun still resolved @galeon/engine-ts's exact @galeon/runtime = "=0.3.0" subdependency from npm unless the generated starter also provided a top-level override.
- The first fix removed that registry-resolution bug, but an apostrophe in the inline JS comment broke the surrounding single-quoted un -e payload on Linux, so the smoke script needed one more shell-safety follow-up.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Fix scope | Patch 	ests/local-first-starter-smoke.sh only | The regression is in pre-publish smoke wiring, not in the published package metadata itself |
| Bun behavior | Add a top-level overrides entry for @galeon/runtime in source mode | Direct ile: dependencies alone were not enough to stop Bun from resolving the exact transitive subdependency from npm |
| Shell safety | Keep the inline Bun patch script free of apostrophes | The smoke script runs under a single-quoted shell payload in CI, so comments inside that block still affect parsing |
| Verification level | Use a focused local repro of the failing smoke path plus shell syntax checks before waiting on GitHub Actions | Confirms both the dependency resolution fix and the Linux shell parse fix without guessing from the previous failed run |

### Changes Made

**Commits:**
- 8500877 ix(#203): keep source-mode starter smoke off unpublished npm deps
- $sha ix(#203): repair starter smoke override snippet quoting

## Testing

- [x] cargo test -p galeon-cli
- [x] ash -n tests/local-first-starter-smoke.sh
- [x] git diff --check
- [x] Targeted repro: scaffolded a local-first starter from current master, rewrote it to source-mode ile: deps plus the new override, and confirmed un install succeeded without requesting @galeon/runtime@=0.3.0 from npm

## Related

- #202
- #201

## Knowledge for Future Reference

For unreleased versions, source-mode starter validation cannot rely on direct local dependencies alone when a workspace package pins an exact subdependency version. Bun's top-level overrides keep pre-publish smoke local, and inline un -e payloads need shell-safe comments because Bash still parses the surrounding single-quoted block before Bun sees the script.

## Review Gate

Independent cross-model review is required before merge per **shiplog**.

---
Authored-by: openai/gpt-5.4 (codex, effort: high)
Last-code-by: openai/gpt-5.4 (codex, effort: high)
Updated-by: openai/gpt-5.4 (codex, effort: high)
Edit-kind: amendment
Edit-note: Added the Linux shell-quoting follow-up after the first smoke-script fix exposed a parse error in the inline un -e payload.
*Captain's log — PR timeline by **shiplog***