### PR TITLE
fix(#219): use minor-line deps in CLI scaffolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and React Three Fiber 9.x. The package now advertises React 18 + R3F 8 and
   React 19 + R3F 9 as its supported peer combinations.
 
+### Fixed
+
+- **CLI scaffold dependency pin (#219)** — `galeon new` Rust templates now emit
+  Galeon crate dependencies on the current major.minor line, such as
+  `galeon-engine = "0.4"`, so generated projects can pick up patch releases
+  without waiting for a new CLI patch release.
+
 ## [0.4.0]
 
 ### Added

--- a/crates/galeon-cli/src/new.rs
+++ b/crates/galeon-cli/src/new.rs
@@ -405,8 +405,8 @@ mod template_dep_tests {
             ("server", &server),
         ] {
             assert!(
-                content.contains(&format!(r#"galeon-engine = "{galeon_version}""#)),
-                "{label} template missing published crate dependency"
+                content.contains(&format!(r#"galeon-engine = "{galeon_minor}""#)),
+                "{label} template missing published crate dependency for current minor line"
             );
             assert!(
                 !content.contains("galeon-engine/galeon.git"),
@@ -415,13 +415,12 @@ mod template_dep_tests {
         }
 
         assert!(
-            local_first_client.contains(&format!(r#"galeon-engine = "{galeon_version}""#)),
-            "local-first client template missing engine dependency pinned to CLI release"
+            local_first_client.contains(&format!(r#"galeon-engine = "{galeon_minor}""#)),
+            "local-first client template missing engine dependency pinned to CLI minor line"
         );
         assert!(
-            local_first_client
-                .contains(&format!(r#"galeon-engine-three-sync = "{galeon_version}""#)),
-            "local-first client template missing three-sync dependency pinned to CLI release"
+            local_first_client.contains(&format!(r#"galeon-engine-three-sync = "{galeon_minor}""#)),
+            "local-first client template missing three-sync dependency pinned to CLI minor line"
         );
         assert!(
             local_first_pkg.contains(&format!(r#""@galeon/engine-ts": "^{galeon_version}""#)),

--- a/crates/galeon-cli/src/templates.rs
+++ b/crates/galeon-cli/src/templates.rs
@@ -55,7 +55,7 @@ edition.workspace = true
 [dependencies]
 galeon-engine = "{}"
 "#,
-        galeon_release_version(),
+        galeon_minor_version(),
     )
 }
 
@@ -84,7 +84,7 @@ edition.workspace = true
 galeon-engine = "{}"
 {name}-protocol = {{ path = "../protocol" }}
 "#,
-        galeon_release_version(),
+        galeon_minor_version(),
     )
 }
 
@@ -141,7 +141,7 @@ galeon-engine = "{}"
 axum = "0.8"
 tokio = {{ version = "1", features = ["full"] }}
 "#,
-        galeon_release_version(),
+        galeon_minor_version(),
     )
 }
 
@@ -560,7 +560,7 @@ galeon-engine-three-sync = "{version}"
 wasm-bindgen = "0.2"
 {name}-domain = {{ path = "../domain" }}
 "#,
-        version = galeon_release_version(),
+        version = galeon_minor_version(),
     )
 }
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,0 +1,24 @@
+# CLI
+
+## Scaffold Smoke Checks
+
+Use this check after changing `galeon new` templates or dependency pins. It
+scaffolds one project for each preset outside the repository and runs
+`cargo check --workspace` in each generated workspace.
+
+```bash
+tmp_dir="$(mktemp -d)"
+repo_cargo="$PWD/Cargo.toml"
+
+for preset in local-first hybrid server-authoritative; do
+  project="check-$preset"
+  (
+    cd "$tmp_dir"
+    cargo run --manifest-path "$repo_cargo" -p galeon-cli -- new "$project" --preset "$preset"
+  )
+  (
+    cd "$tmp_dir/$project"
+    cargo check --workspace
+  )
+done
+```


### PR DESCRIPTION
<!-- shiplog:
kind: history
status: open
readiness: needs-review
issue: 219
updated_at: 2026-05-01T15:38:51Z
-->

## Summary

- Switch galeon new Rust scaffold dependencies from exact CLI patch pins to the current CLI major.minor line.
- Extend the scaffold dependency regression test to assert the minor-line Cargo dependency contract.
- Document the three-preset scaffold smoke check and record the changelog entry.

Closes #219

## Journey Timeline

- b93c605 ix(#219): use minor-line deps in CLI scaffolds
  - Reused galeon_minor_version() for generated Rust Cargo dependencies.
  - Kept npm package dependency range behavior unchanged.
  - Added CLI smoke-check documentation.

## Verification

- [x] cargo fmt --check
- [x] cargo test -p galeon-cli template_dep_tests
- [x] Scaffold local-first, hybrid, and server-authoritative; run cargo check --workspace in each generated project.

## Review Snapshot

Current state: needs-review
Last reviewed by: —
Last reviewed at: —
Reviewed commit: —
Source artifact: —
Needs re-review since: b93c605

Authored-by: openai/gpt-5.5 (codex, effort: high)
Last-code-by: openai/gpt-5.5 (codex, effort: high)
*Captain's log — PR timeline by **shiplog***
Updated-by: openai/gpt-5.5 (codex, effort: high)
Edit-kind: amendment
Edit-note: Rebased PR #220 onto current master and refreshed the timeline commit hash before merge.
