### PR TITLE
fix(#228): guard stale picking entity handles

### DIFF
--- a/crates/engine-three-sync/src/lib.rs
+++ b/crates/engine-three-sync/src/lib.rs
@@ -244,7 +244,7 @@ impl WasmEngine {
         point_z: f32,
         modifier_flags: u32,
     ) {
-        let entity = if entity_present {
+        let raw_entity = if entity_present {
             Some(Entity::from_raw(entity_index, entity_generation))
         } else {
             None
@@ -260,6 +260,7 @@ impl WasmEngine {
         };
         let modifiers = PickModifiers(modifier_flags);
         let world = self.engine.world_mut();
+        let entity = raw_entity.filter(|entity| world.is_alive(*entity));
         if world.try_resource::<Selection>().is_none() {
             world.insert_resource(Selection::new());
         }
@@ -275,12 +276,13 @@ impl WasmEngine {
     /// are ignored.
     #[wasm_bindgen(js_name = applyPickRect)]
     pub fn apply_pick_rect(&mut self, entities_flat: &[u32], modifier_flags: u32) {
+        let modifiers = PickModifiers(modifier_flags);
+        let world = self.engine.world_mut();
         let entities: Vec<Entity> = entities_flat
             .chunks_exact(2)
             .map(|pair| Entity::from_raw(pair[0], pair[1]))
+            .filter(|entity| world.is_alive(*entity))
             .collect();
-        let modifiers = PickModifiers(modifier_flags);
-        let world = self.engine.world_mut();
         if world.try_resource::<Selection>().is_none() {
             world.insert_resource(Selection::new());
         }

--- a/crates/engine-three-sync/tests/picking_bridge.rs
+++ b/crates/engine-three-sync/tests/picking_bridge.rs
@@ -29,6 +29,19 @@ fn spawn_n_cubes(engine: &mut WasmEngine, n: u32) -> Vec<(u32, u32)> {
         .collect()
 }
 
+fn selection_pairs(engine: &WasmEngine) -> Vec<(u32, u32)> {
+    let sel = engine
+        .engine()
+        .world()
+        .try_resource::<Selection>()
+        .expect("selection installed");
+
+    sel.entities
+        .iter()
+        .map(|entity| (entity.index(), entity.generation()))
+        .collect()
+}
+
 #[test]
 fn apply_pick_lazy_installs_selection_resource() {
     let mut engine = WasmEngine::new();
@@ -51,6 +64,31 @@ fn apply_pick_lazy_installs_selection_resource() {
 }
 
 #[test]
+fn apply_pick_filters_stale_entity_handle_before_selection_mutation() {
+    let mut engine = WasmEngine::new();
+    let cubes = spawn_n_cubes(&mut engine, 2);
+
+    engine.apply_pick(true, cubes[0].0, cubes[0].1, false, 0.0, 0.0, 0.0, 0);
+
+    let stale = Entity::from_raw(cubes[1].0, cubes[1].1);
+    assert!(engine.engine_mut().world_mut().despawn(stale));
+
+    engine.apply_pick(
+        true,
+        cubes[1].0,
+        cubes[1].1,
+        false,
+        0.0,
+        0.0,
+        0.0,
+        PickModifiers::SHIFT,
+    );
+
+    let pairs = selection_pairs(&engine);
+    assert_eq!(pairs, vec![cubes[0]]);
+}
+
+#[test]
 fn apply_pick_rect_with_shift_adds_to_selection() {
     let mut engine = WasmEngine::new();
     let cubes = spawn_n_cubes(&mut engine, 5);
@@ -66,6 +104,28 @@ fn apply_pick_rect_with_shift_adds_to_selection() {
     engine.apply_pick_rect(&flat, PickModifiers::SHIFT);
 
     assert_eq!(engine.selection_count(), 4);
+}
+
+#[test]
+fn apply_pick_rect_filters_stale_entity_handles_before_selection_mutation() {
+    let mut engine = WasmEngine::new();
+    let cubes = spawn_n_cubes(&mut engine, 3);
+
+    let stale = Entity::from_raw(cubes[1].0, cubes[1].1);
+    assert!(engine.engine_mut().world_mut().despawn(stale));
+
+    let mut flat = Vec::new();
+    for &(idx, generation) in &cubes {
+        flat.push(idx);
+        flat.push(generation);
+    }
+    engine.apply_pick_rect(&flat, 0);
+
+    let pairs = selection_pairs(&engine);
+    assert_eq!(pairs.len(), 2);
+    assert!(pairs.contains(&cubes[0]));
+    assert!(pairs.contains(&cubes[2]));
+    assert!(!pairs.contains(&cubes[1]));
 }
 
 #[test]


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 228
branch: issue/228-guard-stale-picking-handles
status: resolved
updated_at: 2026-05-02T12:28:00Z
review_status: awaiting-review
-->

## Summary

This PR fixes the late review finding from PR #223 by filtering JavaScript-supplied picking entity handles through Rust world liveness checks before mutating `Selection`. Both single-click picks and drag-rectangle picks now reject stale/despawned handles at the WASM boundary instead of letting them enter Rust-owned selection state.

Closes #228

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan
Fix the late Codex review on merged PR #223 by guarding `applyPick` and `applyPickRect` against stale entity handles and covering the behavior in bridge tests.

### What We Discovered
- The JS-facing `selection_count` and `selection_entities` readback paths already filtered dead entities.
- The incoming write path still let stale handles reach `Selection`, which could leave native readers of `Res<Selection>` with dead entries.

### Implementation Issues
- None.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Liveness ownership | Filter in `crates/engine-three-sync` before calling `Selection` | The raw handles enter from JavaScript at the WASM boundary, and `World::is_alive` is available there. |
| Regression scope | Inspect underlying `Selection`, not only JS readback | Readback already filters dead entries, so tests must prove stale handles never enter Rust-owned state. |

### Changes Made

**Commits:**
- `3e5f239` fix(#228/T1): guard stale picking entity handles

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p galeon-engine-three-sync --test picking_bridge`
- [x] `cargo test -p galeon-engine-three-sync`
- [x] `cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync`
- [x] `cargo clippy -p galeon-engine-three-sync --all-targets -- -D warnings`
- [x] Self-audit: bridge change is limited to liveness filtering and regression tests.

**Verification summary:** Added 2 bridge regression tests covering stale single-click and rectangle handles; all relevant crate and WASM checks pass locally.

## Stacked PRs / Related

- Follow-up to PR #223 and issue #214.
- Late review source: https://github.com/galeon-engine/galeon/pull/223#pullrequestreview-4214903042

## Knowledge for Future Reference

The exported selection read APIs intentionally filter stale entries for JS consumers, but native systems can read `Res<Selection>` directly. Any bridge path accepting raw entity refs from JavaScript should validate them before mutating Rust-owned ECS state.

---
Authored-by: openai/gpt-5.5 (codex, effort: high)
Last-code-by: openai/gpt-5.5 (codex, effort: high)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*