### PR TITLE
feat(#217): route billboards through instanced batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the merged #215 instanced renderer path with screen-aligned vertex behavior
   in both standalone and `InstancedMesh` modes. The Rust extractor routes
   renderable entities carrying `Billboard` and `MeshHandle` into the instanced
-  path, and `@galeon/three` then splits those billboard instances into
-  per-`(instance_group, material_handle)` batches, so texture/material variants
-  split cleanly while 1000 billboards sharing one quad + material still
-  collapse to one `THREE.InstancedMesh` batch.
+  path, and `@galeon/three` now keys instanced batches by
+  `(instance_group, material_handle)`, so texture/material variants split
+  cleanly while 1000 billboards sharing one quad + material still collapse to
+  one `THREE.InstancedMesh` batch. Incremental extraction also flags
+  `Billboard` mesh-handle changes as `CHANGED_INSTANCE_GROUP`, allowing
+  consumers to migrate batches when the billboard quad handle changes.
 
 - **Mouse picking and drag-rectangle selection helper (#214)** — New
   `@galeon/picking` package wraps `THREE.Raycaster` to emit typed `pick` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   exercised by 13 headless `bun:test` cases without requiring a WebGL
   context. Root `package.json` workspaces now extends to `examples/*`.
 
+- **Billboard instancing path wired through `RendererCache` (#217 / T2)** —
+  Billboard materials created by `createBillboardFbmMaterial` now flow through
+  the merged #215 instanced renderer path with screen-aligned vertex behavior
+  in both standalone and `InstancedMesh` modes. The Rust extractor routes
+  renderable entities carrying `Billboard` and `MeshHandle` into the instanced
+  path, and `@galeon/three` then splits those billboard instances into
+  per-`(instance_group, material_handle)` batches, so texture/material variants
+  split cleanly while 1000 billboards sharing one quad + material still
+  collapse to one `THREE.InstancedMesh` batch.
+
 - **Mouse picking and drag-rectangle selection helper (#214)** — New
   `@galeon/picking` package wraps `THREE.Raycaster` to emit typed `pick` and
   `pick-rect` events that resolve back to the entity refs `@galeon/three`

--- a/crates/engine-three-sync/src/extract.rs
+++ b/crates/engine-three-sync/src/extract.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use galeon_engine::render::{
     InstanceOf, MaterialHandle, MeshHandle, ObjectType, ParentEntity, Tint, Transform, Visibility,
 };
-use galeon_engine::{Entity, RenderChannelRegistry, RenderEventRegistry, World};
+use galeon_engine::{Billboard, Entity, RenderChannelRegistry, RenderEventRegistry, World};
 
 use crate::frame_packet::{
     CHANGED_INSTANCE_GROUP, CHANGED_MATERIAL, CHANGED_MESH, CHANGED_OBJECT_TYPE, CHANGED_PARENT,
@@ -57,18 +57,27 @@ fn resolved_tint(world: &World, entity: Entity) -> [f32; 3] {
 type Renderable = (Entity, [f32; 3], [f32; 4], [f32; 3], u32, u8);
 
 fn resolved_instance_group(world: &World, entity: Entity) -> u32 {
-    world
-        .get::<InstanceOf>(entity)
-        .map(|i| {
-            let mesh_id = i.0.id;
-            assert_ne!(
-                mesh_id, INSTANCE_GROUP_NONE,
-                "InstanceOf(MeshHandle {{ id: {mesh_id} }}) collides with \
-                 INSTANCE_GROUP_NONE ({INSTANCE_GROUP_NONE}); id is reserved"
-            );
-            mesh_id
-        })
-        .unwrap_or(INSTANCE_GROUP_NONE)
+    if let Some(instance_of) = world.get::<InstanceOf>(entity) {
+        return checked_instance_group_id(instance_of.0.id, "InstanceOf");
+    }
+
+    if world.get::<Billboard>(entity).is_some() {
+        return world
+            .get::<MeshHandle>(entity)
+            .map(|mesh| checked_instance_group_id(mesh.id, "Billboard MeshHandle"))
+            .unwrap_or(INSTANCE_GROUP_NONE);
+    }
+
+    INSTANCE_GROUP_NONE
+}
+
+fn checked_instance_group_id(mesh_id: u32, source: &str) -> u32 {
+    assert_ne!(
+        mesh_id, INSTANCE_GROUP_NONE,
+        "{source}(MeshHandle {{ id: {mesh_id} }}) collides with \
+         INSTANCE_GROUP_NONE ({INSTANCE_GROUP_NONE}); id is reserved"
+    );
+    mesh_id
 }
 
 fn resolved_parent(world: &World, entity: Entity) -> Option<Entity> {
@@ -210,6 +219,7 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
     let mut object_type_removed: HashSet<Entity> = HashSet::new();
     let mut parent_removed: HashSet<Entity> = HashSet::new();
     let mut instance_group_removed: HashSet<Entity> = HashSet::new();
+    let mut billboard_removed: HashSet<Entity> = HashSet::new();
     let mut tint_removed: HashSet<Entity> = HashSet::new();
     let mut parents_with_new_transform: HashSet<Entity> = HashSet::new();
     let mut renderables: Vec<Renderable> = Vec::new();
@@ -369,6 +379,51 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
         seen.insert(entity);
     }
 
+    for (entity, _) in world.query_changed::<Billboard>(since_tick) {
+        if seen.contains(&entity) {
+            continue;
+        }
+        let Some(transform) = world.get::<Transform>(entity) else {
+            continue;
+        };
+        let object_type = world
+            .get::<ObjectType>(entity)
+            .map(|o| *o as u8)
+            .unwrap_or(0);
+        renderables.push((
+            entity,
+            transform.position,
+            transform.rotation,
+            transform.scale,
+            resolved_parent_id(world, entity),
+            object_type,
+        ));
+        seen.insert(entity);
+    }
+
+    for entity in world.component_removals_since::<Billboard>(since_tick) {
+        billboard_removed.insert(entity);
+        if seen.contains(&entity) {
+            continue;
+        }
+        let Some(transform) = world.get::<Transform>(entity) else {
+            continue;
+        };
+        let object_type = world
+            .get::<ObjectType>(entity)
+            .map(|o| *o as u8)
+            .unwrap_or(0);
+        renderables.push((
+            entity,
+            transform.position,
+            transform.rotation,
+            transform.scale,
+            resolved_parent_id(world, entity),
+            object_type,
+        ));
+        seen.insert(entity);
+    }
+
     for (entity, _) in world.query_changed::<Tint>(since_tick) {
         if seen.contains(&entity) {
             continue;
@@ -502,8 +557,12 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
                 flags |= CHANGED_PARENT;
             }
             if instance_group_removed.contains(entity)
+                || billboard_removed.contains(entity)
                 || arch
                     .column::<InstanceOf>()
+                    .is_some_and(|column| column.changed_tick(row) > since_tick)
+                || arch
+                    .column::<Billboard>()
                     .is_some_and(|column| column.changed_tick(row) > since_tick)
             {
                 flags |= CHANGED_INSTANCE_GROUP;
@@ -1420,6 +1479,75 @@ mod tests {
         let flags = packet.change_flags[0];
         assert!(flags & CHANGED_TRANSFORM != 0);
         assert!(flags & CHANGED_INSTANCE_GROUP == 0);
+    }
+
+    #[test]
+    fn extract_billboard_uses_mesh_handle_as_instance_group() {
+        let mut world = World::new();
+        world.spawn((Transform::identity(), MeshHandle { id: 17 }, Billboard));
+
+        let packet = extract_frame(&world);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.mesh_handles[0], 17);
+        assert_eq!(packet.instance_groups[0], 17);
+    }
+
+    #[test]
+    fn extract_billboard_without_mesh_handle_stays_standalone() {
+        use crate::frame_packet::INSTANCE_GROUP_NONE;
+
+        let mut world = World::new();
+        world.spawn((Transform::identity(), Billboard));
+
+        let packet = extract_frame(&world);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.instance_groups[0], INSTANCE_GROUP_NONE);
+    }
+
+    #[test]
+    fn incremental_extract_flags_billboard_added() {
+        use crate::frame_packet::CHANGED_INSTANCE_GROUP;
+
+        let mut world = World::new();
+        let entity = world.spawn((Transform::identity(), MeshHandle { id: 17 }));
+        let since = world.change_tick();
+        world.advance_tick();
+
+        world.insert(entity, Billboard);
+
+        let packet = extract_frame_incremental(&world, since);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.entity_ids[0], entity.index());
+        assert_eq!(packet.instance_groups[0], 17);
+        let flags = packet.change_flags[0];
+        assert!(
+            flags & CHANGED_INSTANCE_GROUP != 0,
+            "expected CHANGED_INSTANCE_GROUP, got {flags:#b}"
+        );
+        assert!(flags & CHANGED_TRANSFORM == 0);
+    }
+
+    #[test]
+    fn incremental_extract_flags_billboard_removed() {
+        use crate::frame_packet::{CHANGED_INSTANCE_GROUP, INSTANCE_GROUP_NONE};
+
+        let mut world = World::new();
+        let entity = world.spawn((Transform::identity(), MeshHandle { id: 17 }, Billboard));
+        let since = world.change_tick();
+        world.advance_tick();
+
+        world.remove::<Billboard>(entity);
+
+        let packet = extract_frame_incremental(&world, since);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.entity_ids[0], entity.index());
+        assert_eq!(packet.instance_groups[0], INSTANCE_GROUP_NONE);
+        let flags = packet.change_flags[0];
+        assert!(
+            flags & CHANGED_INSTANCE_GROUP != 0,
+            "expected CHANGED_INSTANCE_GROUP, got {flags:#b}"
+        );
+        assert!(flags & CHANGED_TRANSFORM == 0);
     }
 
     #[test]

--- a/crates/engine-three-sync/src/extract.rs
+++ b/crates/engine-three-sync/src/extract.rs
@@ -219,6 +219,7 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
     let mut object_type_removed: HashSet<Entity> = HashSet::new();
     let mut parent_removed: HashSet<Entity> = HashSet::new();
     let mut instance_group_removed: HashSet<Entity> = HashSet::new();
+    let mut mesh_handle_removed: HashSet<Entity> = HashSet::new();
     let mut billboard_removed: HashSet<Entity> = HashSet::new();
     let mut tint_removed: HashSet<Entity> = HashSet::new();
     let mut parents_with_new_transform: HashSet<Entity> = HashSet::new();
@@ -404,6 +405,32 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
         seen.insert(entity);
     }
 
+    for entity in world.component_removals_since::<MeshHandle>(since_tick) {
+        mesh_handle_removed.insert(entity);
+        if world.get::<Billboard>(entity).is_none() {
+            continue;
+        }
+        if seen.contains(&entity) {
+            continue;
+        }
+        let Some(transform) = world.get::<Transform>(entity) else {
+            continue;
+        };
+        let object_type = world
+            .get::<ObjectType>(entity)
+            .map(|o| *o as u8)
+            .unwrap_or(0);
+        renderables.push((
+            entity,
+            transform.position,
+            transform.rotation,
+            transform.scale,
+            resolved_parent_id(world, entity),
+            object_type,
+        ));
+        seen.insert(entity);
+    }
+
     for (entity, _) in world.query_changed::<Billboard>(since_tick) {
         if seen.contains(&entity) {
             continue;
@@ -556,7 +583,7 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
             let mesh_changed = arch
                 .column::<MeshHandle>()
                 .is_some_and(|column| column.changed_tick(row) > since_tick);
-            if mesh_changed {
+            if mesh_handle_removed.contains(entity) || mesh_changed {
                 flags |= CHANGED_MESH;
             }
             if arch
@@ -590,6 +617,9 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
                     .column::<Billboard>()
                     .is_some_and(|column| column.changed_tick(row) > since_tick)
                 || (mesh_changed
+                    && arch.column::<Billboard>().is_some()
+                    && arch.column::<InstanceOf>().is_none())
+                || (mesh_handle_removed.contains(entity)
                     && arch.column::<Billboard>().is_some()
                     && arch.column::<InstanceOf>().is_none())
             {
@@ -1598,6 +1628,34 @@ mod tests {
         assert!(
             flags & CHANGED_INSTANCE_GROUP != 0,
             "expected CHANGED_INSTANCE_GROUP, got {flags:#b}"
+        );
+        assert!(flags & CHANGED_TRANSFORM == 0);
+    }
+
+    #[test]
+    fn incremental_extract_flags_billboard_mesh_handle_removed() {
+        use crate::frame_packet::{CHANGED_INSTANCE_GROUP, CHANGED_MESH, INSTANCE_GROUP_NONE};
+
+        let mut world = World::new();
+        let entity = world.spawn((Transform::identity(), MeshHandle { id: 17 }, Billboard));
+        let since = world.change_tick();
+        world.advance_tick();
+
+        world.remove::<MeshHandle>(entity);
+
+        let packet = extract_frame_incremental(&world, since);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.entity_ids[0], entity.index());
+        assert_eq!(packet.mesh_handles[0], 0);
+        assert_eq!(packet.instance_groups[0], INSTANCE_GROUP_NONE);
+        let flags = packet.change_flags[0];
+        assert!(
+            flags & CHANGED_INSTANCE_GROUP != 0,
+            "expected CHANGED_INSTANCE_GROUP, got {flags:#b}"
+        );
+        assert!(
+            flags & CHANGED_MESH != 0,
+            "expected CHANGED_MESH, got {flags:#b}"
         );
         assert!(flags & CHANGED_TRANSFORM == 0);
     }

--- a/crates/engine-three-sync/src/extract.rs
+++ b/crates/engine-three-sync/src/extract.rs
@@ -379,6 +379,31 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
         seen.insert(entity);
     }
 
+    for (entity, _) in world.query_changed::<MeshHandle>(since_tick) {
+        if world.get::<Billboard>(entity).is_none() {
+            continue;
+        }
+        if seen.contains(&entity) {
+            continue;
+        }
+        let Some(transform) = world.get::<Transform>(entity) else {
+            continue;
+        };
+        let object_type = world
+            .get::<ObjectType>(entity)
+            .map(|o| *o as u8)
+            .unwrap_or(0);
+        renderables.push((
+            entity,
+            transform.position,
+            transform.rotation,
+            transform.scale,
+            resolved_parent_id(world, entity),
+            object_type,
+        ));
+        seen.insert(entity);
+    }
+
     for (entity, _) in world.query_changed::<Billboard>(since_tick) {
         if seen.contains(&entity) {
             continue;
@@ -528,10 +553,10 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
             {
                 flags |= CHANGED_VISIBILITY;
             }
-            if arch
+            let mesh_changed = arch
                 .column::<MeshHandle>()
-                .is_some_and(|column| column.changed_tick(row) > since_tick)
-            {
+                .is_some_and(|column| column.changed_tick(row) > since_tick);
+            if mesh_changed {
                 flags |= CHANGED_MESH;
             }
             if arch
@@ -564,6 +589,9 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
                 || arch
                     .column::<Billboard>()
                     .is_some_and(|column| column.changed_tick(row) > since_tick)
+                || (mesh_changed
+                    && arch.column::<Billboard>().is_some()
+                    && arch.column::<InstanceOf>().is_none())
             {
                 flags |= CHANGED_INSTANCE_GROUP;
             }
@@ -1542,6 +1570,30 @@ mod tests {
         assert_eq!(packet.entity_count(), 1);
         assert_eq!(packet.entity_ids[0], entity.index());
         assert_eq!(packet.instance_groups[0], INSTANCE_GROUP_NONE);
+        let flags = packet.change_flags[0];
+        assert!(
+            flags & CHANGED_INSTANCE_GROUP != 0,
+            "expected CHANGED_INSTANCE_GROUP, got {flags:#b}"
+        );
+        assert!(flags & CHANGED_TRANSFORM == 0);
+    }
+
+    #[test]
+    fn incremental_extract_flags_billboard_mesh_handle_change() {
+        use crate::frame_packet::CHANGED_INSTANCE_GROUP;
+
+        let mut world = World::new();
+        let entity = world.spawn((Transform::identity(), MeshHandle { id: 17 }, Billboard));
+        let since = world.change_tick();
+        world.advance_tick();
+
+        world.get_mut::<MeshHandle>(entity).unwrap().id = 18;
+
+        let packet = extract_frame_incremental(&world, since);
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.entity_ids[0], entity.index());
+        assert_eq!(packet.mesh_handles[0], 18);
+        assert_eq!(packet.instance_groups[0], 18);
         let flags = packet.change_flags[0];
         assert!(
             flags & CHANGED_INSTANCE_GROUP != 0,

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -95,7 +95,40 @@ function update(progress: number) {
 
 The mesh wearing this material **must** use a unit `THREE.PlaneGeometry(1, 1)`
 (positions in `[-0.5, 0.5]^2`). The vertex shader treats `position.xy` as the
-quad-local offset and expects `uv` in `[0, 1]`.
+quad-local offset and expects `uv` in `[0, 1]`. In the instanced path, the
+same shader reads per-instance scale from `instanceMatrix` and keeps the quad
+screen-aligned.
+
+### Instanced billboard routing (T2)
+
+The Rust extractor treats a renderable entity carrying `Billboard` as an
+instanced billboard when it also has a `MeshHandle`. The mesh handle identifies
+the shared unit-quad geometry. `RendererCache` then routes that row through
+`InstancedMeshManager`. For materials created by `createBillboardFbmMaterial`,
+batches are keyed by:
+
+- `instance_groups[i]` (quad mesh group / `InstanceOf(MeshHandle)`)
+- `material_handles[i]` (material/texture variant)
+
+So 1000 billboards sharing one quad mesh handle and one material handle produce
+one `THREE.InstancedMesh` batch; changing material handle splits batches without
+thrashing a shared mesh material.
+
+```rust
+use galeon_engine::{Billboard, MaterialHandle, MeshHandle, Tint, Transform};
+
+world.spawn((
+    Transform::from_position(x, y, z),
+    MeshHandle { id: 17 },                  // quad geometry
+    MaterialHandle { id: 101 },             // billboard material/texture
+    Billboard,                              // opt into billboard instancing
+    Tint([1.0, 1.0, 1.0]),                  // optional per-instance tint
+));
+```
+
+Use `InstanceOf(MeshHandle { id })` directly for non-billboard instancing. For
+billboards, `Billboard` is the semantic marker; `MeshHandle` provides the batch
+geometry key and `MaterialHandle` provides the material/texture split.
 
 ### Uniform reference
 

--- a/packages/three/src/instanced-mesh-manager.ts
+++ b/packages/three/src/instanced-mesh-manager.ts
@@ -165,17 +165,23 @@ export class InstancedMeshManager {
 
   /** The `THREE.InstancedMesh` backing a group key, if one has been created. */
   meshFor(groupKey: InstanceBatchKey): THREE.InstancedMesh | undefined {
-    return this.batches.get(groupKey)?.mesh;
+    return this.batchForQuery(groupKey)?.mesh;
   }
 
   /** Number of live instance slots in a group's batch (== `mesh.count`). */
   slotsFor(groupKey: InstanceBatchKey): number {
-    return this.batches.get(groupKey)?.count ?? 0;
+    return this.batchesForQuery(groupKey).reduce(
+      (count, batch) => count + batch.count,
+      0,
+    );
   }
 
   /** Allocated capacity of a group's batch — distinct from the live `slotsFor` count. */
   capacityFor(groupKey: InstanceBatchKey): number {
-    return this.batches.get(groupKey)?.capacity ?? 0;
+    return this.batchesForQuery(groupKey).reduce(
+      (capacity, batch) => capacity + batch.capacity,
+      0,
+    );
   }
 
   /** Number of distinct mesh-handle batches currently allocated. */
@@ -267,6 +273,30 @@ export class InstancedMeshManager {
     };
     this.batches.set(groupKey, batch);
     return batch;
+  }
+
+  private batchForQuery(groupKey: InstanceBatchKey): Batch | undefined {
+    const direct = this.batches.get(groupKey);
+    if (direct !== undefined) return direct;
+
+    const matches = this.batchesForQuery(groupKey);
+    return matches.length === 1 ? matches[0] : undefined;
+  }
+
+  private batchesForQuery(groupKey: InstanceBatchKey): Batch[] {
+    const direct = this.batches.get(groupKey);
+    if (direct !== undefined) return [direct];
+    if (typeof groupKey === "bigint") return [];
+
+    const prefix = BigInt(groupKey) << 32n;
+    const nextPrefix = BigInt(groupKey + 1) << 32n;
+    const matches: Batch[] = [];
+    for (const [key, batch] of this.batches) {
+      if (typeof key === "bigint" && key >= prefix && key < nextPrefix) {
+        matches.push(batch);
+      }
+    }
+    return matches;
   }
 
   private growBatch(batch: Batch): void {

--- a/packages/three/src/instanced-mesh-manager.ts
+++ b/packages/three/src/instanced-mesh-manager.ts
@@ -3,13 +3,16 @@
 import * as THREE from "three";
 import { TRANSFORM_STRIDE } from "@galeon/render-core";
 
+/** Stable key that identifies one instanced batch. */
+export type InstanceBatchKey = number | bigint;
+
 /** Initial slot capacity allocated when a new instance batch is created. */
 const INITIAL_CAPACITY = 16;
 /** Minimum capacity floor — keeps tiny batches from thrashing the grow path. */
 const MIN_CAPACITY = 4;
 
 /**
- * Per-`MeshHandle` `THREE.InstancedMesh` lifecycle:
+ * Per-group `THREE.InstancedMesh` lifecycle:
  *
  * - **Lazy creation** — a batch is allocated the first time an entity with that
  *   group key arrives.
@@ -25,7 +28,7 @@ const MIN_CAPACITY = 4;
  * rules (placeholder, missing-handle warnings, override-survival semantics).
  */
 interface Batch {
-  readonly groupKey: number;
+  readonly groupKey: InstanceBatchKey;
   mesh: THREE.InstancedMesh;
   capacity: number;
   count: number;
@@ -45,11 +48,11 @@ const _scratchColor = new THREE.Color();
 
 export class InstancedMeshManager {
   private readonly scene: THREE.Scene;
-  private readonly batches = new Map<number, Batch>();
+  private readonly batches = new Map<InstanceBatchKey, Batch>();
   /** `entityId → (groupKey, slot)` — single source of truth for placement. */
   private readonly entityToPlacement = new Map<
     number,
-    { groupKey: number; slot: number }
+    { groupKey: InstanceBatchKey; slot: number }
   >();
 
   constructor(scene: THREE.Scene) {
@@ -72,14 +75,14 @@ export class InstancedMeshManager {
    */
   upsert(
     entityId: number,
-    groupKey: number,
+    groupKey: InstanceBatchKey,
     geometry: THREE.BufferGeometry,
     material: THREE.Material,
     transforms: Float32Array,
     transformIndex: number,
     visible: boolean,
     tints?: Float32Array,
-  ): { groupKey: number; slot: number } {
+  ): { groupKey: InstanceBatchKey; slot: number } {
     const existing = this.entityToPlacement.get(entityId);
     if (existing !== undefined && existing.groupKey !== groupKey) {
       this.remove(entityId);
@@ -161,17 +164,17 @@ export class InstancedMeshManager {
   // ---------------------------------------------------------------------------
 
   /** The `THREE.InstancedMesh` backing a group key, if one has been created. */
-  meshFor(groupKey: number): THREE.InstancedMesh | undefined {
+  meshFor(groupKey: InstanceBatchKey): THREE.InstancedMesh | undefined {
     return this.batches.get(groupKey)?.mesh;
   }
 
   /** Number of live instance slots in a group's batch (== `mesh.count`). */
-  slotsFor(groupKey: number): number {
+  slotsFor(groupKey: InstanceBatchKey): number {
     return this.batches.get(groupKey)?.count ?? 0;
   }
 
   /** Allocated capacity of a group's batch — distinct from the live `slotsFor` count. */
-  capacityFor(groupKey: number): number {
+  capacityFor(groupKey: InstanceBatchKey): number {
     return this.batches.get(groupKey)?.capacity ?? 0;
   }
 
@@ -219,7 +222,7 @@ export class InstancedMeshManager {
   // ---------------------------------------------------------------------------
 
   private getOrCreateBatch(
-    groupKey: number,
+    groupKey: InstanceBatchKey,
     geometry: THREE.BufferGeometry,
     material: THREE.Material,
   ): Batch {

--- a/packages/three/src/materials/billboard-fbm.ts
+++ b/packages/three/src/materials/billboard-fbm.ts
@@ -2,6 +2,23 @@
 
 import * as THREE from "three";
 
+const BILLBOARD_FBM_MATERIAL_MARK = Symbol.for("galeon.billboard-fbm");
+const BILLBOARD_FBM_PROGRAM_KEY = "galeon.billboard-fbm.v1";
+
+/**
+ * Type guard for materials produced by `createBillboardFbmMaterial`.
+ */
+export function isBillboardFbmMaterial(
+  material: THREE.Material,
+): material is THREE.ShaderMaterial {
+  return (
+    material instanceof THREE.ShaderMaterial &&
+    (material.userData as Record<PropertyKey, unknown>)[
+      BILLBOARD_FBM_MATERIAL_MARK
+    ] === true
+  );
+}
+
 /**
  * Reference billboard material for Galeon particle effects.
  *
@@ -104,11 +121,21 @@ varying float vEyeDepth;
 void main() {
   vUv = uv;
 
-  // Camera-facing billboard: place the quad center at the model origin in
-  // view space, then offset by the quad-local position scaled by uSize.
-  vec4 mvCenter = modelViewMatrix * vec4(0.0, 0.0, 0.0, 1.0);
-  vec3 offset = vec3(position.xy * uSize, 0.0);
-  vec4 mvPosition = mvCenter + vec4(offset, 0.0);
+  // Camera-facing billboard:
+  // 1) place the quad center at the mesh/instance origin in view space
+  // 2) offset corners in camera-plane by uSize, preserving instance scale.
+  vec4 mvCenter;
+  vec2 billboardScale = vec2(1.0, 1.0);
+  #ifdef USE_INSTANCING
+    vec4 worldCenter = modelMatrix * instanceMatrix * vec4(0.0, 0.0, 0.0, 1.0);
+    mvCenter = viewMatrix * worldCenter;
+    billboardScale = vec2(length(instanceMatrix[0].xyz), length(instanceMatrix[1].xyz));
+  #else
+    mvCenter = modelViewMatrix * vec4(0.0, 0.0, 0.0, 1.0);
+  #endif
+
+  vec2 quadOffset = position.xy * (uSize * billboardScale);
+  vec4 mvPosition = mvCenter + vec4(quadOffset, 0.0, 0.0);
   vEyeDepth = -mvPosition.z;
   gl_Position = projectionMatrix * mvPosition;
 }
@@ -243,7 +270,7 @@ export function createBillboardFbmMaterial(
 
   const hasDepthFade = softEdgeDistance > 0 && depthTexture !== null;
 
-  return new THREE.ShaderMaterial({
+  const material = new THREE.ShaderMaterial({
     defines: { OCTAVES: octaves },
     uniforms: {
       uColor: { value: color },
@@ -268,4 +295,15 @@ export function createBillboardFbmMaterial(
     blendDst: THREE.OneMinusSrcAlphaFactor,
     blendEquation: THREE.AddEquation,
   });
+
+  // Keep a stable program key marker so billboard materials can be routed into
+  // billboard-specific instancing batches without clashing with other shaders.
+  const prevProgramKey = material.customProgramCacheKey.bind(material);
+  material.customProgramCacheKey = (): string =>
+    `${prevProgramKey()}|${BILLBOARD_FBM_PROGRAM_KEY}`;
+  (material.userData as Record<PropertyKey, unknown>)[
+    BILLBOARD_FBM_MATERIAL_MARK
+  ] = true;
+
+  return material;
 }

--- a/packages/three/src/renderer-cache.ts
+++ b/packages/three/src/renderer-cache.ts
@@ -18,7 +18,6 @@ import {
   InstancedMeshManager,
   type InstanceBatchKey,
 } from "./instanced-mesh-manager.js";
-import { isBillboardFbmMaterial } from "./materials/billboard-fbm.js";
 
 /**
  * Renderer-side cache that consumes packed extraction tables from the
@@ -187,9 +186,9 @@ export class RendererCache {
       // ----- Instanced routing -----
       // Entities tagged with `InstanceOf` skip the standalone-Object3D path
       // and live in `THREE.InstancedMesh` batches instead.
-      // Default batch key is the wrapped `MeshHandle.id`; billboard materials
-      // are split by `(instanceGroup, materialHandle)` to keep per-texture /
-      // per-material variants in separate batches.
+      // Batch key is `(instanceGroup, materialHandle)`: the Rust group
+      // chooses geometry, and the material handle keeps each InstancedMesh on
+      // one material.
       const groupKey = instanceGroups?.[i] ?? INSTANCE_GROUP_NONE;
       if (groupKey !== INSTANCE_GROUP_NONE) {
         // If the entity was previously standalone, tear it down before
@@ -209,7 +208,6 @@ export class RendererCache {
         const batchKey = this.resolveInstanceBatchKey(
           groupKey,
           matHandle,
-          material,
         );
         this.instancedMeshes.upsert(
           entityId,
@@ -608,18 +606,14 @@ export class RendererCache {
 
   /**
    * Instancing key policy:
-   * - General instancing: batch by Rust `InstanceOf(MeshHandle)` group id.
-   * - Billboard FBM materials: batch by `(instanceGroup, materialHandle)` so
-   *   different texture/material variants do not thrash one shared batch.
+   * Batch by `(instanceGroup, materialHandle)` so one `THREE.InstancedMesh`
+   * never has to represent rows with different materials. This covers both
+   * Billboard-derived groups and general `InstanceOf` groups.
    */
   private resolveInstanceBatchKey(
     instanceGroup: number,
     materialHandle: number,
-    material: THREE.Material,
   ): InstanceBatchKey {
-    if (!isBillboardFbmMaterial(material)) {
-      return instanceGroup;
-    }
     return (
       (BigInt(instanceGroup) << INSTANCE_KEY_SHIFT) |
       (BigInt(materialHandle) & INSTANCE_KEY_MASK)

--- a/packages/three/src/renderer-cache.ts
+++ b/packages/three/src/renderer-cache.ts
@@ -14,7 +14,11 @@ import {
   SCENE_ROOT,
   TRANSFORM_STRIDE,
 } from "@galeon/render-core";
-import { InstancedMeshManager } from "./instanced-mesh-manager.js";
+import {
+  InstancedMeshManager,
+  type InstanceBatchKey,
+} from "./instanced-mesh-manager.js";
+import { isBillboardFbmMaterial } from "./materials/billboard-fbm.js";
 
 /**
  * Renderer-side cache that consumes packed extraction tables from the
@@ -34,6 +38,8 @@ import { InstancedMeshManager } from "./instanced-mesh-manager.js";
  * Using a Symbol avoids namespace collisions with string-keyed custom render channels.
  */
 export const GALEON_ENTITY_KEY: unique symbol = Symbol.for("galeon.entity");
+const INSTANCE_KEY_SHIFT = 32n;
+const INSTANCE_KEY_MASK = 0xffff_ffffn;
 
 export interface RendererEntityHandle {
   readonly entityId: number;
@@ -180,9 +186,10 @@ export class RendererCache {
 
       // ----- Instanced routing -----
       // Entities tagged with `InstanceOf` skip the standalone-Object3D path
-      // and live inside a per-`MeshHandle` `THREE.InstancedMesh` instead.
-      // Group key equals the wrapped `MeshHandle.id` (see Rust frame_packet),
-      // so the same handle drives geometry resolution and batch routing.
+      // and live in `THREE.InstancedMesh` batches instead.
+      // Default batch key is the wrapped `MeshHandle.id`; billboard materials
+      // are split by `(instanceGroup, materialHandle)` to keep per-texture /
+      // per-material variants in separate batches.
       const groupKey = instanceGroups?.[i] ?? INSTANCE_GROUP_NONE;
       if (groupKey !== INSTANCE_GROUP_NONE) {
         // If the entity was previously standalone, tear it down before
@@ -199,9 +206,14 @@ export class RendererCache {
         const material =
           this.materials.get(matHandle) ?? this.placeholderMaterial;
         const visible = visibility[i]! === 1;
+        const batchKey = this.resolveInstanceBatchKey(
+          groupKey,
+          matHandle,
+          material,
+        );
         this.instancedMeshes.upsert(
           entityId,
-          groupKey,
+          batchKey,
           geometry,
           material,
           transforms,
@@ -592,5 +604,25 @@ export class RendererCache {
     } else {
       this.warnedMaterials.delete(entityId);
     }
+  }
+
+  /**
+   * Instancing key policy:
+   * - General instancing: batch by Rust `InstanceOf(MeshHandle)` group id.
+   * - Billboard FBM materials: batch by `(instanceGroup, materialHandle)` so
+   *   different texture/material variants do not thrash one shared batch.
+   */
+  private resolveInstanceBatchKey(
+    instanceGroup: number,
+    materialHandle: number,
+    material: THREE.Material,
+  ): InstanceBatchKey {
+    if (!isBillboardFbmMaterial(material)) {
+      return instanceGroup;
+    }
+    return (
+      (BigInt(instanceGroup) << INSTANCE_KEY_SHIFT) |
+      (BigInt(materialHandle) & INSTANCE_KEY_MASK)
+    );
   }
 }

--- a/packages/three/tests/billboard-fbm.test.ts
+++ b/packages/three/tests/billboard-fbm.test.ts
@@ -2,12 +2,16 @@
 
 import { describe, expect, test } from "bun:test";
 import * as THREE from "three";
-import { createBillboardFbmMaterial } from "../src/materials/billboard-fbm.js";
+import {
+  createBillboardFbmMaterial,
+  isBillboardFbmMaterial,
+} from "../src/materials/billboard-fbm.js";
 
 describe("createBillboardFbmMaterial — defaults", () => {
   test("returns a ShaderMaterial", () => {
     const m = createBillboardFbmMaterial();
     expect(m).toBeInstanceOf(THREE.ShaderMaterial);
+    expect(isBillboardFbmMaterial(m)).toBe(true);
   });
 
   test("warm off-white default color (0.95, 0.92, 0.85)", () => {
@@ -143,6 +147,8 @@ describe("createBillboardFbmMaterial — shader source", () => {
     expect(m.vertexShader).toContain("modelViewMatrix");
     expect(m.vertexShader).toContain("uSize");
     expect(m.vertexShader).toContain("vEyeDepth");
+    expect(m.vertexShader).toContain("USE_INSTANCING");
+    expect(m.vertexShader).toContain("instanceMatrix");
   });
 
   test("fragment shader contains FBM, lifetime fade, and depth-fade branch", () => {

--- a/packages/three/tests/instanced-mesh.test.ts
+++ b/packages/three/tests/instanced-mesh.test.ts
@@ -767,4 +767,64 @@ describe("RendererCache billboard instancing follow-up (#217 T2)", () => {
     expect(meshes.map((mesh) => mesh.material)).toContain(matA);
     expect(meshes.map((mesh) => mesh.material)).toContain(matB);
   });
+
+  test("non-FBM billboard materials split instance batches by material handle", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(17, new THREE.PlaneGeometry(1, 1));
+    const matA = new THREE.MeshBasicMaterial({ color: 0xffaa33 });
+    const matB = new THREE.MeshBasicMaterial({ color: 0x33aaff });
+    cache.registerMaterial(201, matA);
+    cache.registerMaterial(202, matB);
+
+    const packet = makePacket({ entity_count: 2 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 1;
+    packet.entity_ids[1] = 2;
+    packet.mesh_handles[0] = 17;
+    packet.mesh_handles[1] = 17;
+    packet.material_handles[0] = 201;
+    packet.material_handles[1] = 202;
+    (packet as { instance_groups?: Uint32Array }).instance_groups =
+      new Uint32Array([17, 17]);
+
+    cache.applyFrame(packet);
+
+    const meshes = scene.children.filter(
+      (obj): obj is THREE.InstancedMesh => obj instanceof THREE.InstancedMesh,
+    );
+    expect(meshes).toHaveLength(2);
+    expect(cache.instancing.batchCount).toBe(2);
+    expect(meshes.map((mesh) => mesh.material)).toContain(matA);
+    expect(meshes.map((mesh) => mesh.material)).toContain(matB);
+  });
+
+  test("non-billboard InstanceOf entities sharing a material stay in one batch", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(17, new THREE.PlaneGeometry(1, 1));
+    const material = new THREE.MeshBasicMaterial({ color: 0xffaa33 });
+    cache.registerMaterial(301, material);
+
+    const packet = makePacket({ entity_count: 2 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 1;
+    packet.entity_ids[1] = 2;
+    packet.mesh_handles[0] = 17;
+    packet.mesh_handles[1] = 17;
+    packet.material_handles[0] = 301;
+    packet.material_handles[1] = 301;
+    (packet as { instance_groups?: Uint32Array }).instance_groups =
+      new Uint32Array([17, 17]);
+
+    cache.applyFrame(packet);
+
+    expect(cache.instancing.batchCount).toBe(1);
+    const meshes = scene.children.filter(
+      (obj): obj is THREE.InstancedMesh => obj instanceof THREE.InstancedMesh,
+    );
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0]!.count).toBe(2);
+    expect(meshes[0]!.material).toBe(material);
+  });
 });

--- a/packages/three/tests/instanced-mesh.test.ts
+++ b/packages/three/tests/instanced-mesh.test.ts
@@ -12,6 +12,7 @@ import {
   TRANSFORM_STRIDE,
   type FramePacketView,
 } from "../../render-core/src/index.js";
+import { createBillboardFbmMaterial } from "../src/materials/billboard-fbm.js";
 import { RendererCache } from "../src/renderer-cache.js";
 
 interface PacketOverrides extends Partial<FramePacketView> {
@@ -699,5 +700,71 @@ describe("RendererCache instanced tint channel (#215 T3)", () => {
     }
     expect(observed).toContainEqual([1, 0, 0]);
     expect(observed).toContainEqual([1, 1, 0]);
+  });
+});
+
+describe("RendererCache billboard instancing follow-up (#217 T2)", () => {
+  test("1000 billboard entities produce one instanced billboard batch", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    const quad = new THREE.PlaneGeometry(1, 1);
+    const billboardMaterial = createBillboardFbmMaterial();
+    cache.registerGeometry(17, quad);
+    cache.registerMaterial(101, billboardMaterial);
+
+    const N = 1000;
+    const packet = makePacket({ entity_count: N });
+    fillIdentityTransforms(packet);
+    for (let i = 0; i < N; i++) {
+      packet.entity_ids[i] = i + 1;
+      packet.mesh_handles[i] = 17;
+      packet.material_handles[i] = 101;
+    }
+    (packet as { instance_groups?: Uint32Array }).instance_groups =
+      new Uint32Array(N).fill(17);
+
+    cache.applyFrame(packet);
+
+    const meshes = scene.children.filter(
+      (obj): obj is THREE.InstancedMesh => obj instanceof THREE.InstancedMesh,
+    );
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0]!.count).toBeGreaterThanOrEqual(N);
+    expect(meshes[0]!.geometry).toBe(quad);
+    expect(meshes[0]!.material).toBe(billboardMaterial);
+    expect(cache.instancing.batchCount).toBe(1);
+    expect(cache.objectCount).toBe(0);
+  });
+
+  test("billboards split instance batches by material handle", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(17, new THREE.PlaneGeometry(1, 1));
+    const matA = createBillboardFbmMaterial({ color: 0xffddaa });
+    const matB = createBillboardFbmMaterial({ color: 0xaaddff });
+    cache.registerMaterial(101, matA);
+    cache.registerMaterial(102, matB);
+
+    const packet = makePacket({ entity_count: 2 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 1;
+    packet.entity_ids[1] = 2;
+    packet.mesh_handles[0] = 17;
+    packet.mesh_handles[1] = 17;
+    packet.material_handles[0] = 101;
+    packet.material_handles[1] = 102;
+    (packet as { instance_groups?: Uint32Array }).instance_groups =
+      new Uint32Array([17, 17]);
+
+    cache.applyFrame(packet);
+
+    const meshes = scene.children.filter(
+      (obj): obj is THREE.InstancedMesh => obj instanceof THREE.InstancedMesh,
+    );
+    expect(meshes).toHaveLength(2);
+    expect(cache.instancing.batchCount).toBe(2);
+    expect(meshes.map((mesh) => mesh.count)).toEqual([1, 1]);
+    expect(meshes.map((mesh) => mesh.material)).toContain(matA);
+    expect(meshes.map((mesh) => mesh.material)).toContain(matB);
   });
 });


### PR DESCRIPTION
<!-- shiplog:kind: historyissue: 217branch: issue/217-billboard-instancing-t2status: resolvedupdated_at: 2026-05-02T13:03:52Z- 171ed4b fix(#217/T2): address billboard instancing review## Testing- [x] `cargo fmt --all -- --check`- [x] `cargo test -p galeon-engine-three-sync extract`- [x] `cargo test --workspace`- [x] `cargo clippy -p galeon-engine -p galeon-engine-three-sync --all-targets -- -D warnings`- [x] `cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync`- [x] `bun run check`- [x] `bun test packages/three examples/billboards`- [x] `bun test`## Stacked PRs / Related- Builds on the #215 instanced mesh path, already merged.- Completes the remaining T2 task from #217 after PR #227 shipped T1/T3/T4.## Knowledge for Future ReferenceUse `Billboard` as the semantic marker for billboard instancing. Use `InstanceOf(MeshHandle { id })` directly for non-billboard instancing; for billboards, `MeshHandle` supplies the quad geometry group and `MaterialHandle` supplies the texture/material split.---Authored-by: openai/gpt-5.5 (codex, effort: high; orchestrator)Last-code-by: openai/gpt-5.5 (codex, effort: high; orchestrator)Implementation-lane-by: openai/gpt-5.3-codex (codex, effort: xhigh; sub-agent: implementation)Updated-by: openai/gpt-5.5 (codex, effort: high; orchestrator)Edit-kind: correctionEdit-note: Corrected Markdown formatting after PR creation escaped backticks in the body.*Captain's log - PR timeline by **shiplog***Updated-by: openai/gpt-5.5 (codex, effort: high; orchestrator)Edit-kind: amendmentEdit-note: Recorded commit 171ed4b addressing Codex review feedback and marked the PR for re-review.
Updated-by: openai/gpt-5.5 (codex, effort: high; orchestrator)
Edit-kind: amendment
Edit-note: Recorded commit 26e3367 addressing the Codex MeshHandle-removal follow-up and kept the PR marked for re-review.
