### PR TITLE
docs(#232,#234): pin release and terrain conventions

### DIFF
--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -57,9 +57,10 @@ Run the bump script from the repo root:
 bash scripts/bump-version.sh A.B.C
 ```
 
-This updates all 9 files (16 edits) after verifying the current versions are
-consistent, and rolls back if verification fails. `galeon-cli` inherits the
-workspace version automatically, so it does not need a separate version edit.
+This updates Galeon's shared version sources (12 edits across 9 files) after
+verifying the current versions are consistent, and rolls back if verification
+fails. `galeon-cli` inherits the workspace version automatically, so it does not
+need a separate version edit.
 The script supports prerelease and build metadata tags
 (`0.4.0-alpha.1`, `0.4.0-alpha-1+build-7`).
 

--- a/docs/guide/terrain.md
+++ b/docs/guide/terrain.md
@@ -25,9 +25,17 @@ let mut engine = Engine::new();
 engine.add_plugin(HeightmapPlugin::new(terrain));
 ```
 
+`Terrain` height samples are row-major in local X/Z space. Sample columns move
+in world +X, sample rows move in world +Z, and sample `(0, 0)` is located at
+`origin`. The `size` argument spans from sample `(0, 0)` to
+`(width - 1, height - 1)`, so adjacent sample spacing is
+`size / (sample_count - 1)` per axis.
+
 `height_at(x, z)` bilinearly samples the source grid and returns `None` outside
 the terrain bounds. `normal_at(x, z)` estimates a normal from central
-differences over the same source grid.
+differences over the same source grid using the same world X/Z convention. This
+query normal is for gameplay and sampling; render mesh normals belong to the
+future mesh builder.
 
 ## PNG16 Loading
 
@@ -38,3 +46,11 @@ range while keeping `height_min` fixed.
 DEM, GeoTIFF, tile streaming, and LOD are intentionally out of scope for this
 engine primitive. Downstream applications can convert those sources into
 authored PNG16 heightmaps before handing data to Galeon.
+
+## Mesh Export Convention
+
+When terrain mesh export is added, it must preserve the same sample mapping:
+world +X maps to source columns and world +Z maps to row-major source rows. The
+mesh contract must document vertex order, winding, and normal direction, and
+must keep generated render normals separate from `normal_at` source-query
+normals.


### PR DESCRIPTION
<!-- shiplog:kind: historyissue: 232branch: issue/232-release-doc-countstatus: resolvedreadiness: needs-reviewupdated_at: 2026-05-02T15:47:57Zupdated_by: openai/gpt-5.5 (codex, effort: high)edit_kind: amendment-->## SummaryFixes the stale release bump edit-count wording from #232 and pins the terrain coordinate convention requested by #234. This is documentation-only: no runtime behavior changes.Closes #232Closes #234## Review Status- **Current state:** approved- **Last reviewed by:** openai/gpt-5.4 (codex, effort: high)- **Last reviewed at:** 2026-05-02T15:52:00Z- **Reviewed commit:** 8f8e1e1- **Source artifact:** https://github.com/galeon-engine/galeon/pull/235#issuecomment-4364176700- **Needs re-review since:** -## Journey Timeline### Changes Made- docs/guide/publishing.md now matches scripts/bump-version.sh: 12 edits across 9 files.- docs/guide/terrain.md now documents row-major X/Z sampling, source-query normals, and the future mesh export convention.### Verification- [x] ash -n scripts/bump-version.sh- [x] ash scripts/bump-version.sh 0.4.0 read all 12 locations and stopped at the expected same-version no-op.- [x] git diff --check## Knowledge For Future ReferenceTerrain mesh export should preserve the source heightmap mapping: world +X maps to columns, world +Z maps to row-major rows, and generated render normals stay separate from Terrain::normal_at query normals.---Authored-by: openai/gpt-5.5 (codex, effort: high)Last-code-by: openai/gpt-5.5 (codex, effort: high)*Captain's log - PR timeline by **shiplog***

Updated-by: openai/gpt-5.5 (codex, effort: high)
Edit-kind: amendment
Edit-note: Refreshed Review Status snapshot after cross-model approval on PR #235.