### PR TITLE
perf(#233): share terrain height storage across clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Shared height storage for terrain resources (#233)** — `Terrain` now keeps
+  height samples in immutable shared storage, so cloning a terrain resource or
+  installing it through `HeightmapPlugin` no longer copies the full height
+  buffer. The public ECS resource type remains `Terrain`.
+
 - **React 19 support for `@galeon/r3f` (#211)** — Verified the R3F
   provider/hooks test path against React 19.2, React DOM 19.2, Three 0.183.x,
   and React Three Fiber 9.x. The package now advertises React 18 + R3F 8 and

--- a/crates/engine-terrain/src/lib.rs
+++ b/crates/engine-terrain/src/lib.rs
@@ -3,6 +3,7 @@
 use std::error::Error;
 use std::fmt;
 use std::io::{BufRead, Seek};
+use std::sync::Arc;
 
 use galeon_engine::{Engine, Plugin};
 
@@ -17,7 +18,7 @@ pub struct Terrain {
     size: [f32; 2],
     sample_count: [u32; 2],
     pixel_stride: [f32; 2],
-    heights: Vec<f32>,
+    heights: Arc<[f32]>,
     min_height: f32,
     max_height: f32,
 }
@@ -60,7 +61,7 @@ impl Terrain {
             size,
             sample_count: [width, height],
             pixel_stride: [size[0] / (width - 1) as f32, size[1] / (height - 1) as f32],
-            heights,
+            heights: heights.into(),
             min_height,
             max_height,
         })
@@ -461,11 +462,25 @@ mod tests {
     #[test]
     fn heightmap_plugin_inserts_terrain_resource() {
         let terrain = synthetic_4x4();
+        let height_storage = terrain.heights().as_ptr();
         let mut engine = Engine::new();
 
         engine.add_plugin(HeightmapPlugin::new(terrain.clone()));
 
         assert_eq!(engine.world().resource::<Terrain>(), &terrain);
+        assert_eq!(
+            engine.world().resource::<Terrain>().heights().as_ptr(),
+            height_storage
+        );
+    }
+
+    #[test]
+    fn terrain_clone_shares_immutable_height_storage() {
+        let terrain = synthetic_4x4();
+        let clone = terrain.clone();
+
+        assert_eq!(clone, terrain);
+        assert_eq!(clone.heights().as_ptr(), terrain.heights().as_ptr());
     }
 
     #[test]

--- a/docs/guide/terrain.md
+++ b/docs/guide/terrain.md
@@ -37,6 +37,10 @@ differences over the same source grid using the same world X/Z convention. This
 query normal is for gameplay and sampling; render mesh normals belong to the
 future mesh builder.
 
+Cloning a `Terrain` shares immutable height storage. `HeightmapPlugin` still
+installs a normal `Terrain` resource, so systems can read `Res<Terrain>` without
+an `Arc` wrapper, but plugin installation does not copy the full height buffer.
+
 ## PNG16 Loading
 
 `Terrain::from_png16_reader` accepts 16-bit grayscale PNG data and maps each


### PR DESCRIPTION
<!-- shiplog:kind: historyissue: 233branch: issue/233-shared-terrain-ownershipstatus: resolvedreadiness: needs-reviewupdated_at: 2026-05-02T15:53:12Zupdated_by: openai/gpt-5.5 (codex, effort: high)edit_kind: amendment-->## SummaryStores Terrain height samples in immutable shared storage so cloning a terrain resource, including the clone performed by HeightmapPlugin::build, no longer copies the full height buffer. The public ECS resource type remains Terrain, so existing Res<Terrain> and world.resource::<Terrain>() callers do not need an Arc wrapper.Closes #233## Review Status- **Current state:** approved- **Last reviewed by:** openai/gpt-5.3-codex (codex, effort: xhigh; sub-agent: reviewer)- **Last reviewed at:** 2026-05-02T15:57:00Z- **Reviewed commit:** abbc4d9- **Source artifact:** https://github.com/galeon-engine/galeon/pull/236#issuecomment-4364185501- **Needs re-review since:** -## Journey Timeline### Design ChoiceUse Arc<[f32]> inside Terrain rather than storing Arc<Terrain> as the ECS resource. This removes the install-time full-buffer clone while preserving the existing resource API and Rust-first terrain ownership model.### Changes Made- Terrain::heights now stores immutable shared height samples.- Terrain::new still accepts Vec<f32> and validates it before converting to shared storage.- Added tests proving Terrain::clone() and HeightmapPlugin installation preserve the height buffer pointer.- Updated docs/guide/terrain.md and CHANGELOG.md with the ownership behavior.### Verification- [x] cargo test -p galeon-engine-terrain — 9 passed- [x] cargo clippy -p galeon-engine-terrain --all-targets -- -D warnings- [x] cargo fmt --all -- --check- [x] git diff --check origin/master..HEAD## Knowledge For Future ReferenceThe stable public contract remains Terrain as the resource type. The shared ownership is an implementation detail of immutable height storage, not a new ECS resource wrapper.---Authored-by: openai/gpt-5.5 (codex, effort: high)Last-code-by: openai/gpt-5.5 (codex, effort: high)*Captain's log - PR timeline by **shiplog***

Updated-by: openai/gpt-5.5 (codex, effort: high)
Edit-kind: amendment
Edit-note: Refreshed Review Status snapshot after cross-model approval on PR #236.