### PR TITLE
feat(#213): add terrain mesh export and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Heightmap terrain engine primitive (#213 / T1-T2)** — New
+- **Heightmap terrain engine primitive (#213)** — New
   `galeon-engine-terrain` crate provides a Rust-owned `Terrain` resource with
   bilinear `height_at(x, z)` sampling, central-difference `normal_at(x, z)`
   queries, bounds / stride metadata, and a `HeightmapPlugin` that installs the
   loaded terrain into the engine world. The crate also loads 16-bit grayscale
   PNG heightmaps with explicit origin, size, height range, and vertical
-  exaggeration options. DEM / GeoTIFF ingestion, terrain mesh sync, LOD, and
-  examples remain deferred follow-up work.
+  exaggeration options. `TerrainMesh::from_terrain` generates a CPU-side
+  triangle-list buffer with local positions, finite-difference normals, and
+  upward-facing indices, while `HeightmapPlugin::with_render_mesh` can spawn a
+  renderable terrain entity through the existing `FramePacket` mesh/material
+  handle path. A native `cargo run -p galeon-engine-terrain --example terrain`
+  example exercises PNG16 loading, mesh generation, sample queries, and
+  three-sync extraction. DEM / GeoTIFF ingestion, tiled LOD, UV/splat mapping,
+  and physics collider export remain deferred follow-up work.
 
 - **Particle emitter primitive (#217 / T1)** — New `galeon_engine::particle`
   module ships an `Emitter` component (`rate`, `lifetime`, `velocity`, `size`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ name = "galeon-engine-terrain"
 version = "0.4.0"
 dependencies = [
  "galeon-engine",
+ "galeon-engine-three-sync",
  "png",
 ]
 

--- a/crates/engine-terrain/Cargo.toml
+++ b/crates/engine-terrain/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["game-development"]
 [dependencies]
 galeon-engine = { path = "../engine", version = "=0.4.0" }
 png = { workspace = true }
+
+[dev-dependencies]
+galeon-engine-three-sync = { path = "../engine-three-sync", version = "=0.4.0" }

--- a/crates/engine-terrain/examples/terrain.rs
+++ b/crates/engine-terrain/examples/terrain.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+use std::error::Error;
+use std::io::Cursor;
+
+use galeon_engine::{Engine, MaterialHandle, MeshHandle};
+use galeon_engine_terrain::{HeightmapPlugin, Png16HeightmapOptions, Terrain, TerrainMesh};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let png = synthetic_ridge_png16(5, 5)?;
+    let terrain = Terrain::from_png16_reader(
+        Cursor::new(png),
+        Png16HeightmapOptions {
+            origin: [-2.0, -2.0],
+            size: [4.0, 4.0],
+            height_min: 0.0,
+            height_max: 8.0,
+            vertical_exaggeration: 1.0,
+        },
+    )?;
+
+    let mut engine = Engine::new();
+    engine.add_plugin(
+        HeightmapPlugin::new(terrain)
+            .with_render_mesh(MeshHandle { id: 100 }, MaterialHandle { id: 200 }),
+    );
+
+    let terrain = engine.world().resource::<Terrain>();
+    let mesh = engine.world().resource::<TerrainMesh>();
+    let packet = galeon_engine_three_sync::extract_frame(engine.world());
+
+    assert_eq!(mesh.vertex_count(), 25);
+    assert_eq!(packet.entity_count(), 1);
+    assert_eq!(packet.mesh_handles[0], 100);
+    assert_eq!(packet.material_handles[0], 200);
+
+    let center_height = terrain.height_at(0.0, 0.0).unwrap();
+    let center_normal = terrain.normal_at(0.0, 0.0).unwrap();
+    assert!((center_height - 4.0).abs() < 0.01);
+    assert!(center_normal[1] > 0.5);
+
+    println!(
+        "terrain example: vertices={}, entity={}, center_height={center_height:.2}, center_normal={center_normal:?}",
+        mesh.vertex_count(),
+        packet.entity_ids[0],
+    );
+
+    Ok(())
+}
+
+fn synthetic_ridge_png16(width: u32, height: u32) -> Result<Vec<u8>, png::EncodingError> {
+    let mut bytes = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut bytes, width, height);
+        encoder.set_color(png::ColorType::Grayscale);
+        encoder.set_depth(png::BitDepth::Sixteen);
+        let mut writer = encoder.write_header()?;
+        let max = (width - 1 + height - 1) as f32;
+        let mut data = Vec::with_capacity(width as usize * height as usize * 2);
+        for z in 0..height {
+            for x in 0..width {
+                let raw = (((x + z) as f32 / max) * u16::MAX as f32).round() as u16;
+                data.extend_from_slice(&raw.to_be_bytes());
+            }
+        }
+        writer.write_image_data(&data)?;
+    }
+    Ok(bytes)
+}

--- a/crates/engine-terrain/src/lib.rs
+++ b/crates/engine-terrain/src/lib.rs
@@ -249,6 +249,29 @@ impl Terrain {
     fn sample_at(&self, x: u32, z: u32) -> f32 {
         self.heights[(z * self.sample_count[0] + x) as usize]
     }
+
+    fn normal_at_sample(&self, x: u32, z: u32) -> [f32; 3] {
+        debug_assert!(x < self.sample_count[0]);
+        debug_assert!(z < self.sample_count[1]);
+
+        let max_x = self.sample_count[0] - 1;
+        let max_z = self.sample_count[1] - 1;
+        let left_x = x.saturating_sub(1);
+        let right_x = (x + 1).min(max_x);
+        let down_z = z.saturating_sub(1);
+        let up_z = (z + 1).min(max_z);
+
+        let left = self.sample_at(left_x, z);
+        let right = self.sample_at(right_x, z);
+        let down = self.sample_at(x, down_z);
+        let up = self.sample_at(x, up_z);
+
+        let dx = (right_x - left_x) as f32 * self.pixel_stride[0];
+        let dz = (up_z - down_z) as f32 * self.pixel_stride[1];
+        let dhdx = (right - left) / dx;
+        let dhdz = (up - down) / dz;
+        normalize([-dhdx, 1.0, -dhdz]).expect("normal vector includes +Y component")
+    }
 }
 
 /// CPU-side terrain mesh generated from a [`Terrain`] height grid.
@@ -281,11 +304,7 @@ impl TerrainMesh {
                 let local_z = z as f32 * stride_z;
                 positions.extend_from_slice(&[local_x, terrain.sample_at(x, z), local_z]);
 
-                let world_x = terrain.origin[0] + local_x;
-                let world_z = terrain.origin[1] + local_z;
-                let normal = terrain
-                    .normal_at(world_x, world_z)
-                    .unwrap_or([0.0, 1.0, 0.0]);
+                let normal = terrain.normal_at_sample(x, z);
                 normals.extend_from_slice(&normal);
             }
         }
@@ -638,6 +657,35 @@ mod tests {
         let center_normal = &mesh.normals()[12..15];
         for i in 0..3 {
             assert!((center_normal[i] - expected[i]).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn terrain_mesh_computes_edge_normals_from_grid_samples() {
+        let terrain = Terrain::new(
+            [0.0, 0.0],
+            [0.1, 0.1],
+            4,
+            4,
+            vec![
+                0.0, 1.0, 2.0, 3.0, //
+                1.0, 2.0, 3.0, 4.0, //
+                2.0, 3.0, 4.0, 5.0, //
+                3.0, 4.0, 5.0, 6.0,
+            ],
+        )
+        .unwrap();
+
+        let mesh = TerrainMesh::from_terrain(&terrain);
+        let last_normal = &mesh.normals()[45..48];
+        let gradient = 1.0 / (0.1_f32 / 3.0);
+        let expected = normalize([-gradient, 1.0, -gradient]).unwrap();
+
+        for i in 0..3 {
+            assert!(
+                (last_normal[i] - expected[i]).abs() < 1e-6,
+                "component {i}: expected {expected:?}, got {last_normal:?}",
+            );
         }
     }
 

--- a/crates/engine-terrain/src/lib.rs
+++ b/crates/engine-terrain/src/lib.rs
@@ -5,7 +5,9 @@ use std::fmt;
 use std::io::{BufRead, Seek};
 use std::sync::Arc;
 
-use galeon_engine::{Engine, Plugin};
+use galeon_engine::{
+    Engine, MaterialHandle, MeshHandle, ObjectType, Plugin, Transform, Visibility,
+};
 
 /// Heightfield sampled over the X/Z plane.
 ///
@@ -249,6 +251,90 @@ impl Terrain {
     }
 }
 
+/// CPU-side terrain mesh generated from a [`Terrain`] height grid.
+///
+/// Positions and normals are flat `[x, y, z]` arrays. Positions are local to
+/// the terrain origin: X/Z start at `0.0`, while Y stores the sampled height.
+/// The render entity spawned by [`HeightmapPlugin::with_render_mesh`] carries a
+/// transform at the terrain's world X/Z origin.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerrainMesh {
+    positions: Vec<f32>,
+    normals: Vec<f32>,
+    indices: Vec<u32>,
+}
+
+impl TerrainMesh {
+    /// Generate a triangle mesh from every source height sample.
+    pub fn from_terrain(terrain: &Terrain) -> Self {
+        let [width, height] = terrain.sample_count();
+        let [stride_x, stride_z] = terrain.pixel_stride();
+        let vertex_count = width as usize * height as usize;
+        let quad_count = (width - 1) as usize * (height - 1) as usize;
+        let mut positions = Vec::with_capacity(vertex_count * 3);
+        let mut normals = Vec::with_capacity(vertex_count * 3);
+        let mut indices = Vec::with_capacity(quad_count * 6);
+
+        for z in 0..height {
+            for x in 0..width {
+                let local_x = x as f32 * stride_x;
+                let local_z = z as f32 * stride_z;
+                positions.extend_from_slice(&[local_x, terrain.sample_at(x, z), local_z]);
+
+                let world_x = terrain.origin[0] + local_x;
+                let world_z = terrain.origin[1] + local_z;
+                let normal = terrain
+                    .normal_at(world_x, world_z)
+                    .unwrap_or([0.0, 1.0, 0.0]);
+                normals.extend_from_slice(&normal);
+            }
+        }
+
+        for z in 0..(height - 1) {
+            for x in 0..(width - 1) {
+                let top_left = z * width + x;
+                let top_right = top_left + 1;
+                let bottom_left = top_left + width;
+                let bottom_right = bottom_left + 1;
+                indices.extend_from_slice(&[
+                    top_left,
+                    bottom_left,
+                    top_right,
+                    top_right,
+                    bottom_left,
+                    bottom_right,
+                ]);
+            }
+        }
+
+        Self {
+            positions,
+            normals,
+            indices,
+        }
+    }
+
+    /// Number of generated vertices.
+    pub fn vertex_count(&self) -> usize {
+        self.positions.len() / 3
+    }
+
+    /// Flat `[x, y, z]` vertex positions, local to the terrain origin.
+    pub fn positions(&self) -> &[f32] {
+        &self.positions
+    }
+
+    /// Flat `[x, y, z]` vertex normals.
+    pub fn normals(&self) -> &[f32] {
+        &self.normals
+    }
+
+    /// Triangle index buffer. Winding faces up toward +Y.
+    pub fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+}
+
 /// PNG16 heightmap import options.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Png16HeightmapOptions {
@@ -271,20 +357,66 @@ impl Default for Png16HeightmapOptions {
     }
 }
 
+/// Optional render entity settings for [`HeightmapPlugin`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerrainRenderSettings {
+    pub mesh_handle: MeshHandle,
+    pub material_handle: MaterialHandle,
+}
+
+impl TerrainRenderSettings {
+    pub fn new(mesh_handle: MeshHandle, material_handle: MaterialHandle) -> Self {
+        Self {
+            mesh_handle,
+            material_handle,
+        }
+    }
+}
+
 /// Plugin that installs a loaded [`Terrain`] resource.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeightmapPlugin {
     terrain: Terrain,
+    render: Option<TerrainRenderSettings>,
 }
 
 impl HeightmapPlugin {
     pub fn new(terrain: Terrain) -> Self {
-        Self { terrain }
+        Self {
+            terrain,
+            render: None,
+        }
+    }
+
+    /// Also generate a [`TerrainMesh`] resource and spawn one renderable entity.
+    ///
+    /// The spawned entity uses the provided mesh/material handles and a
+    /// transform positioned at the terrain's X/Z origin. Consumers still own
+    /// mapping `mesh_handle` to a Three.js `BufferGeometry`; this method keeps
+    /// the frame packet on the existing renderable-entity channel.
+    pub fn with_render_mesh(
+        mut self,
+        mesh_handle: MeshHandle,
+        material_handle: MaterialHandle,
+    ) -> Self {
+        self.render = Some(TerrainRenderSettings::new(mesh_handle, material_handle));
+        self
     }
 }
 
 impl Plugin for HeightmapPlugin {
     fn build(&self, engine: &mut Engine) {
+        if let Some(render) = self.render {
+            engine.insert_resource(TerrainMesh::from_terrain(&self.terrain));
+            let origin = self.terrain.origin();
+            engine.world_mut().spawn((
+                Transform::from_position(origin[0], 0.0, origin[1]),
+                Visibility { visible: true },
+                render.mesh_handle,
+                render.material_handle,
+                ObjectType::Mesh,
+            ));
+        }
         engine.insert_resource(self.terrain.clone());
     }
 }
@@ -472,6 +604,63 @@ mod tests {
             engine.world().resource::<Terrain>().heights().as_ptr(),
             height_storage
         );
+    }
+
+    #[test]
+    fn terrain_mesh_generates_vertices_normals_and_indices() {
+        let terrain = Terrain::new(
+            [0.0, 0.0],
+            [2.0, 2.0],
+            3,
+            3,
+            vec![
+                0.0, 1.0, 2.0, //
+                1.0, 2.0, 3.0, //
+                2.0, 3.0, 4.0,
+            ],
+        )
+        .unwrap();
+
+        let mesh = TerrainMesh::from_terrain(&terrain);
+
+        assert_eq!(mesh.vertex_count(), (2 + 1) * (2 + 1));
+        assert_eq!(mesh.positions().len(), 9 * 3);
+        assert_eq!(mesh.normals().len(), 9 * 3);
+        assert_eq!(mesh.indices().len(), 2 * 2 * 6);
+        assert_eq!(&mesh.positions()[0..3], &[0.0, 0.0, 0.0]);
+        assert_eq!(&mesh.positions()[24..27], &[2.0, 4.0, 2.0]);
+
+        let expected = [
+            -1.0 / 3.0_f32.sqrt(),
+            1.0 / 3.0_f32.sqrt(),
+            -1.0 / 3.0_f32.sqrt(),
+        ];
+        let center_normal = &mesh.normals()[12..15];
+        for i in 0..3 {
+            assert!((center_normal[i] - expected[i]).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn heightmap_plugin_emits_terrain_render_entity_through_frame_packet() {
+        let terrain = synthetic_4x4();
+        let mut engine = Engine::new();
+
+        engine.add_plugin(
+            HeightmapPlugin::new(terrain)
+                .with_render_mesh(MeshHandle { id: 77 }, MaterialHandle { id: 9 }),
+        );
+
+        let mesh = engine.world().resource::<TerrainMesh>();
+        assert_eq!(mesh.vertex_count(), (4 - 1 + 1) * (4 - 1 + 1));
+
+        let packet = galeon_engine_three_sync::extract_frame(engine.world());
+        assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.mesh_handles[0], 77);
+        assert_eq!(packet.material_handles[0], 9);
+        assert_eq!(packet.transforms[0], 10.0);
+        assert_eq!(packet.transforms[1], 0.0);
+        assert_eq!(packet.transforms[2], 20.0);
     }
 
     #[test]

--- a/docs/guide/terrain.md
+++ b/docs/guide/terrain.md
@@ -34,8 +34,9 @@ in world +X, sample rows move in world +Z, and sample `(0, 0)` is located at
 `height_at(x, z)` bilinearly samples the source grid and returns `None` outside
 the terrain bounds. `normal_at(x, z)` estimates a normal from central
 differences over the same source grid using the same world X/Z convention. This
-query normal is for gameplay and sampling; render mesh normals belong to the
-future mesh builder.
+query normal is for gameplay and sampling. The generated render mesh uses the
+same first-pass finite-difference convention today, but the `TerrainMesh` buffer
+is a render adapter rather than the authoritative data source.
 
 Cloning a `Terrain` shares immutable height storage. `HeightmapPlugin` still
 installs a normal `Terrain` resource, so systems can read `Res<Terrain>` without
@@ -51,10 +52,24 @@ DEM, GeoTIFF, tile streaming, and LOD are intentionally out of scope for this
 engine primitive. Downstream applications can convert those sources into
 authored PNG16 heightmaps before handing data to Galeon.
 
-## Mesh Export Convention
+## Mesh Export
 
-When terrain mesh export is added, it must preserve the same sample mapping:
-world +X maps to source columns and world +Z maps to row-major source rows. The
-mesh contract must document vertex order, winding, and normal direction, and
-must keep generated render normals separate from `normal_at` source-query
-normals.
+`TerrainMesh::from_terrain(&terrain)` generates a CPU-side triangle-list mesh
+from the source samples:
+
+- `positions()`: flat `[x, y, z]` triples, local to the terrain origin.
+- `normals()`: flat `[x, y, z]` triples, pointing toward +Y for flat terrain.
+- `indices()`: `u32` triangle indices with upward-facing winding.
+
+The vertex grid preserves the same sample mapping: world +X maps to source
+columns and world +Z maps to row-major source rows. A terrain with `width *
+height` samples produces `width * height` vertices, or `(quad_count_x + 1) *
+(quad_count_z + 1)`.
+
+`HeightmapPlugin::with_render_mesh(mesh_handle, material_handle)` installs the
+`TerrainMesh` resource and spawns one renderable terrain entity through the
+existing `Transform` + `MeshHandle` + `MaterialHandle` extraction path. The
+spawned entity is positioned at the terrain's X/Z origin. TypeScript consumers
+still own converting `TerrainMesh` data into a Three.js `BufferGeometry` and
+registering it against the chosen mesh handle; the `FramePacket` contract stays
+unchanged.


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 213
branch: issue/213-terrain-mesh-example
status: resolved
updated_at: 2026-05-02T17:10:09Z
review_status: awaiting-rereview
-->

## Summary

This PR completes #213 by adding the terrain mesh/export half of the heightmap primitive. It keeps Terrain as the authoritative Rust CPU resource, adds a generated TerrainMesh adapter buffer, and emits an opt-in renderable terrain entity through the existing three-sync MeshHandle/MaterialHandle frame-packet path.

Closes #213

## Review Status

- **Current state:** awaiting re-review after feedback fix
- **Last reviewed by:** chatgpt-codex-connector
- **Last reviewed at:** 2026-05-02T16:12:42Z
- **Reviewed commit:** 4ba580f
- **Source artifact:** https://github.com/galeon-engine/galeon/pull/237#pullrequestreview-4215232864
- **Needs re-review since:** 2111142

## Journey Timeline

### Initial Plan
Finish the remaining #213 tasks after PR #231 delivered the Terrain resource and PNG16 loader: T3 mesh generation / three-sync integration and T4 native terrain example.

### What We Discovered
- Current FramePacket carries renderable entity rows and asset handles, not vertex payloads. The implementation therefore generates a Rust-side TerrainMesh buffer and uses existing Transform + MeshHandle + MaterialHandle extraction rather than widening the packet contract.
- A Bevy prior-art refresh confirmed the data-resource vs render-adapter split and the need to pin triangle winding / +Y normals in docs and tests.

### Implementation Issues
- None blocking. The only adjustment was preserving the current frame-packet contract instead of introducing mesh payload transport in this issue.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Terrain data ownership | Keep Terrain authoritative and make TerrainMesh an adapter | Matches Bevy prior art and Galeon's Rust-first rule |
| Frame transport | Emit a render entity with mesh/material handles | Avoids expanding FramePacket for vertex data before the renderer asset contract exists |
| Mesh convention | Row-major source samples, local X/Z positions, +Y winding/normals | Gives Three.js consumers a stable geometry contract |

### Changes Made

**Commits:**
- 4ba580f feat(#213/T3-T4): add terrain mesh export and example
- 2111142 fix(#213): compute terrain mesh normals from grid samples

## Testing

- [x] cargo fmt --all -- --check
- [x] cargo test -p galeon-engine-terrain
- [x] cargo run -p galeon-engine-terrain --example terrain
- [x] cargo clippy -p galeon-engine-terrain --all-targets -- -D warnings
- [x] cargo check --workspace
- [x] cargo run --example terrain
- [x] cargo test --workspace
- [x] git diff --check

**Verification summary:** Added terrain mesh unit coverage, a three-sync extraction integration assertion from the terrain crate, and a native example smoke that loads procedural PNG16 terrain, generates a mesh, samples height/normal, and extracts a terrain render entity. Review follow-up adds an edge-normal regression for a 0.1-sized 4x4 grid and verifies mesh normals are generated from integer source samples.

## Stacked PRs / Related

- PR #231 delivered #213 T1/T2.
- PR #235 and PR #236 landed related follow-up cleanup from PR #231 review.

## Knowledge for Future Reference

TerrainMesh is intentionally a CPU-side Galeon buffer, not a Three.js type. TS consumers still need a small adapter that converts positions/normals/indices into THREE.BufferGeometry and registers it against the chosen mesh handle. UVs, splat maps, collider export, Sobel normals, and tiled LOD remain out of scope.

---
Authored-by: openai/gpt-5 (codex)
Updated-by: openai/gpt-5 (codex)
Edit-kind: amendment
Edit-note: Added review feedback commit, re-review status, and edge-normal regression verification.
Last-code-by: openai/gpt-5 (codex)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*