### PR TITLE
fix(#224): resolve instanced picking identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Instanced click picking preserves entity identity (#224)** —
+  `@galeon/three` now stamps each managed `THREE.InstancedMesh` batch with an
+  `instanceId -> { entityId, generation }` resolver, and `@galeon/picking`
+  consults `Intersection.instanceId` before falling back to the standalone
+  object/ancestor stamp path. Clicks on entities routed through
+  `InstanceOf(MeshHandle)` or billboard instancing now forward the selected
+  entity handle to Rust instead of missing the shared batch object.
+
 - **Confirmed-click spawn in `examples/billboards` (#217)** — Burst spawning
   now triggers on `pointerup` only when the pointer has not moved beyond a
   drag threshold since `pointerdown`, instead of firing on `pointerdown`.

--- a/docs/guide/picking.md
+++ b/docs/guide/picking.md
@@ -51,6 +51,13 @@ dispose();
 resolves to the entity stamped on the group. NDC math uses
 `getBoundingClientRect()`, so the canvas does not need to be fullscreen.
 
+Instanced render batches also resolve to Galeon entity handles for click
+picking. `@galeon/three` stamps each `THREE.InstancedMesh` with an
+`instanceId -> { entityId, generation }` resolver, and `@galeon/picking` uses
+the `THREE.Raycaster` intersection's `instanceId` before falling back to the
+normal ancestor-stamp path. Marquee selection still uses object AABBs; large
+per-instance marquee acceleration remains a follow-up under #224.
+
 ## Rust: `Selection` resource
 
 ```rust
@@ -94,7 +101,9 @@ reports the modifiers; the `Selection` resource decides what they mean.
 - **Multi-rect / lasso selection** — single rectangle only.
 - **GPU-accelerated picking** — when scenes scale past what raycasting can
   handle, look at `@three.ez/instanced-mesh` (per-instance BVH) or
-  `three-mesh-bvh` (static geometry). The discovery notes have details.
+  `three-mesh-bvh` (static geometry). The default click path already preserves
+  instanced entity identity through `Intersection.instanceId`; faster backends
+  must preserve the same `{ entityId, generation }` result shape.
 
 ## Native Verification
 

--- a/packages/picking/src/picking.ts
+++ b/packages/picking/src/picking.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 
 import * as THREE from "three";
-import { GALEON_ENTITY_KEY } from "@galeon/three";
+import {
+  GALEON_ENTITY_KEY,
+  GALEON_INSTANCE_ENTITIES_KEY,
+  type InstancedEntityResolver,
+} from "@galeon/three";
 import { frustumFromRect } from "./selection-frustum.js";
 
 /**
@@ -234,6 +238,11 @@ function pickPoint(
   raycaster.setFromCamera(ndc, camera);
   const intersections = raycaster.intersectObjects(scene.children, true);
   for (const hit of intersections) {
+    const instanceEntity = readInstanceEntity(hit);
+    if (instanceEntity != null) {
+      const p = hit.point;
+      return { entity: instanceEntity, point: { x: p.x, y: p.y, z: p.z } };
+    }
     const entity = visibleAncestorEntity(hit.object);
     if (entity != null) {
       const p = hit.point;
@@ -241,6 +250,18 @@ function pickPoint(
     }
   }
   return null;
+}
+
+function readInstanceEntity(hit: THREE.Intersection): PickingEntityRef | null {
+  const instanceId = hit.instanceId;
+  if (instanceId == null) return null;
+  const data = hit.object.userData as Record<PropertyKey, unknown> | undefined;
+  const resolver = data?.[GALEON_INSTANCE_ENTITIES_KEY] as
+    | InstancedEntityResolver
+    | undefined;
+  const entity = resolver?.entityAt(instanceId);
+  if (entity == null) return null;
+  return entity;
 }
 
 /**

--- a/packages/picking/src/picking.ts
+++ b/packages/picking/src/picking.ts
@@ -238,7 +238,7 @@ function pickPoint(
   raycaster.setFromCamera(ndc, camera);
   const intersections = raycaster.intersectObjects(scene.children, true);
   for (const hit of intersections) {
-    const instanceEntity = readInstanceEntity(hit);
+    const instanceEntity = visibleInstanceEntity(hit);
     if (instanceEntity != null) {
       const p = hit.point;
       return { entity: instanceEntity, point: { x: p.x, y: p.y, z: p.z } };
@@ -250,6 +250,11 @@ function pickPoint(
     }
   }
   return null;
+}
+
+function visibleInstanceEntity(hit: THREE.Intersection): PickingEntityRef | null {
+  if (!visibleObjectChain(hit.object)) return null;
+  return readInstanceEntity(hit);
 }
 
 function readInstanceEntity(hit: THREE.Intersection): PickingEntityRef | null {
@@ -397,6 +402,15 @@ function readEntity(object: THREE.Object3D): PickingEntityRef | null {
     return null;
   }
   return { entityId: stamped.entityId, generation: stamped.generation };
+}
+
+function visibleObjectChain(object: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = object;
+  while (current != null) {
+    if (!current.visible) return false;
+    current = current.parent;
+  }
+  return true;
 }
 
 function visibleAncestorEntity(object: THREE.Object3D): PickingEntityRef | null {

--- a/packages/picking/tests/instanced-picking.test.ts
+++ b/packages/picking/tests/instanced-picking.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import { describe, expect, test } from "bun:test";
+import * as THREE from "three";
+import {
+  INSTANCE_GROUP_NONE,
+  RENDER_CONTRACT_VERSION,
+  RendererCache,
+  SCENE_ROOT,
+  TRANSFORM_STRIDE,
+  type FramePacketView,
+} from "@galeon/three";
+import { attachPicking, type PickingEvent } from "../src/picking.js";
+
+interface PacketOverrides extends Partial<FramePacketView> {
+  entity_count: number;
+}
+
+function makePacket(overrides: PacketOverrides): FramePacketView {
+  const count = overrides.entity_count;
+  return {
+    contract_version: RENDER_CONTRACT_VERSION,
+    entity_count: count,
+    entity_ids: new Uint32Array(count),
+    entity_generations: new Uint32Array(count),
+    transforms: new Float32Array(count * TRANSFORM_STRIDE),
+    visibility: new Uint8Array(count).fill(1),
+    mesh_handles: new Uint32Array(count),
+    material_handles: new Uint32Array(count),
+    parent_ids: new Uint32Array(count).fill(SCENE_ROOT),
+    custom_channel_count: 0,
+    custom_channel_name_at: () => "",
+    custom_channel_stride: () => 1,
+    custom_channel_data: () => new Float32Array(0),
+    event_count: 0,
+    event_kinds: new Uint32Array(0),
+    event_entities: new Uint32Array(0),
+    event_positions: new Float32Array(0),
+    event_intensities: new Float32Array(0),
+    event_data: new Float32Array(0),
+    ...overrides,
+  };
+}
+
+function fillIdentityTransforms(packet: FramePacketView): void {
+  for (let i = 0; i < packet.entity_count; i++) {
+    const off = i * TRANSFORM_STRIDE;
+    packet.transforms[off + 6] = 1;
+    packet.transforms[off + 7] = 1;
+    packet.transforms[off + 8] = 1;
+    packet.transforms[off + 9] = 1;
+  }
+}
+
+class CanvasStub {
+  private readonly listeners = new Map<string, Set<(event: MouseEvent) => void>>();
+
+  addEventListener(type: string, listener: (event: MouseEvent) => void): void {
+    let listeners = this.listeners.get(type);
+    if (listeners === undefined) {
+      listeners = new Set();
+      this.listeners.set(type, listeners);
+    }
+    listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MouseEvent) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  getBoundingClientRect(): { left: number; top: number; width: number; height: number } {
+    return { left: 0, top: 0, width: 100, height: 100 };
+  }
+
+  dispatch(type: string, event: MouseEvent): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function mouse(type: string, clientX: number, clientY: number): MouseEvent {
+  return {
+    type,
+    button: 0,
+    clientX,
+    clientY,
+    shiftKey: false,
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+  } as MouseEvent;
+}
+
+describe("@galeon/picking instanced mesh identity (#224)", () => {
+  test("click pick resolves InstancedMesh instanceId to entity generation", () => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld();
+
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const packet = makePacket({ entity_count: 2 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 10;
+    packet.entity_generations[0] = 3;
+    packet.mesh_handles[0] = 7;
+    packet.transforms[0] = 0;
+    packet.transforms[1] = 0;
+    packet.transforms[2] = 0;
+    packet.entity_ids[1] = 11;
+    packet.entity_generations[1] = 4;
+    packet.mesh_handles[1] = 7;
+    packet.transforms[TRANSFORM_STRIDE] = 3;
+    packet.transforms[TRANSFORM_STRIDE + 1] = 0;
+    packet.transforms[TRANSFORM_STRIDE + 2] = 0;
+    packet.instance_groups = new Uint32Array([7, 7]);
+
+    cache.applyFrame(packet);
+
+    const canvas = new CanvasStub();
+    const events: PickingEvent[] = [];
+    const dispose = attachPicking(canvas, scene, camera, {
+      onPick: (event) => events.push(event),
+    });
+
+    canvas.dispatch("mousedown", mouse("mousedown", 50, 50));
+    canvas.dispatch("mouseup", mouse("mouseup", 50, 50));
+    dispose();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.kind).toBe("pick");
+    if (events[0]!.kind !== "pick") throw new Error("expected pick event");
+    expect(events[0]!.entity).toEqual({ entityId: 10, generation: 3 });
+    expect(events[0]!.point).not.toBeNull();
+  });
+
+  test("standalone picks still use object entity stamps", () => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const packet = makePacket({ entity_count: 1 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 12;
+    packet.entity_generations[0] = 5;
+    packet.mesh_handles[0] = 7;
+    packet.instance_groups = new Uint32Array([INSTANCE_GROUP_NONE]);
+    cache.applyFrame(packet);
+
+    const canvas = new CanvasStub();
+    const events: PickingEvent[] = [];
+    const dispose = attachPicking(canvas, scene, camera, {
+      onPick: (event) => events.push(event),
+    });
+
+    canvas.dispatch("mousedown", mouse("mousedown", 50, 50));
+    canvas.dispatch("mouseup", mouse("mouseup", 50, 50));
+    dispose();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.kind).toBe("pick");
+    if (events[0]!.kind !== "pick") throw new Error("expected pick event");
+    expect(events[0]!.entity).toEqual({ entityId: 12, generation: 5 });
+  });
+});

--- a/packages/picking/tests/instanced-picking.test.ts
+++ b/packages/picking/tests/instanced-picking.test.ts
@@ -139,6 +139,43 @@ describe("@galeon/picking instanced mesh identity (#224)", () => {
     expect(events[0]!.point).not.toBeNull();
   });
 
+  test("click pick ignores hidden InstancedMesh hits", () => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld();
+
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const packet = makePacket({ entity_count: 1 });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 10;
+    packet.entity_generations[0] = 3;
+    packet.mesh_handles[0] = 7;
+    packet.instance_groups = new Uint32Array([7]);
+    cache.applyFrame(packet);
+    cache.instancing.meshFor(7)!.visible = false;
+
+    const canvas = new CanvasStub();
+    const events: PickingEvent[] = [];
+    const dispose = attachPicking(canvas, scene, camera, {
+      onPick: (event) => events.push(event),
+    });
+
+    canvas.dispatch("mousedown", mouse("mousedown", 50, 50));
+    canvas.dispatch("mouseup", mouse("mouseup", 50, 50));
+    dispose();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.kind).toBe("pick");
+    if (events[0]!.kind !== "pick") throw new Error("expected pick event");
+    expect(events[0]!.entity).toBeNull();
+    expect(events[0]!.point).toBeNull();
+  });
+
   test("standalone picks still use object entity stamps", () => {
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);

--- a/packages/three/src/index.ts
+++ b/packages/three/src/index.ts
@@ -6,7 +6,12 @@ export {
   type RendererEntityHandle,
 } from "./renderer-cache.js";
 
-export { InstancedMeshManager } from "./instanced-mesh-manager.js";
+export {
+  GALEON_INSTANCE_ENTITIES_KEY,
+  InstancedMeshManager,
+  type InstancedEntityRef,
+  type InstancedEntityResolver,
+} from "./instanced-mesh-manager.js";
 
 export {
   createBillboardFbmMaterial,

--- a/packages/three/src/instanced-mesh-manager.ts
+++ b/packages/three/src/instanced-mesh-manager.ts
@@ -3,6 +3,20 @@
 import * as THREE from "three";
 import { TRANSFORM_STRIDE } from "@galeon/render-core";
 
+/** Symbol key for resolving `THREE.InstancedMesh` hit `instanceId`s to Galeon entities. */
+export const GALEON_INSTANCE_ENTITIES_KEY: unique symbol = Symbol.for(
+  "galeon.instanceEntities",
+);
+
+export interface InstancedEntityRef {
+  readonly entityId: number;
+  readonly generation: number;
+}
+
+export interface InstancedEntityResolver {
+  entityAt(instanceId: number): InstancedEntityRef | undefined;
+}
+
 /** Stable key that identifies one instanced batch. */
 export type InstanceBatchKey = number | bigint;
 
@@ -34,6 +48,8 @@ interface Batch {
   count: number;
   /** `slot → entityId` (`-1` for empty slots, but only `[0, count)` is meaningful). */
   slotToEntity: Int32Array;
+  /** `slot → entity generation`, parallel to `slotToEntity`. */
+  slotToGeneration: Uint32Array;
   /** Last registry-resolved geometry and material for this batch. */
   geometry: THREE.BufferGeometry;
   material: THREE.Material;
@@ -75,6 +91,7 @@ export class InstancedMeshManager {
    */
   upsert(
     entityId: number,
+    generation: number,
     groupKey: InstanceBatchKey,
     geometry: THREE.BufferGeometry,
     material: THREE.Material,
@@ -100,10 +117,12 @@ export class InstancedMeshManager {
       }
       slot = batch.count;
       batch.slotToEntity[slot] = entityId;
+      batch.slotToGeneration[slot] = generation;
       batch.count += 1;
       batch.mesh.count = batch.count;
       this.entityToPlacement.set(entityId, { groupKey, slot });
     }
+    batch.slotToGeneration[slot] = generation;
 
     this.writeSlotMatrix(batch, slot, transforms, transformIndex, visible);
     if (tints !== undefined) {
@@ -139,7 +158,9 @@ export class InstancedMeshManager {
       batch.mesh.getColorAt(lastSlot, _scratchColor);
       batch.mesh.setColorAt(slot, _scratchColor);
       const movedEntity = batch.slotToEntity[lastSlot]!;
+      const movedGeneration = batch.slotToGeneration[lastSlot]!;
       batch.slotToEntity[slot] = movedEntity;
+      batch.slotToGeneration[slot] = movedGeneration;
       this.entityToPlacement.set(movedEntity, {
         groupKey: batch.groupKey,
         slot,
@@ -151,6 +172,7 @@ export class InstancedMeshManager {
     }
 
     batch.slotToEntity[lastSlot] = -1;
+    batch.slotToGeneration[lastSlot] = 0;
     batch.count = lastSlot;
     batch.mesh.count = batch.count;
     batch.mesh.instanceMatrix.needsUpdate = true;
@@ -268,9 +290,11 @@ export class InstancedMeshManager {
       capacity,
       count: 0,
       slotToEntity: createSlotArray(capacity),
+      slotToGeneration: new Uint32Array(capacity),
       geometry,
       material,
     };
+    attachResolver(mesh, batch);
     this.batches.set(groupKey, batch);
     return batch;
   }
@@ -328,10 +352,14 @@ export class InstancedMeshManager {
 
     const newSlots = createSlotArray(newCapacity);
     newSlots.set(batch.slotToEntity.subarray(0, batch.count));
+    const newGenerations = new Uint32Array(newCapacity);
+    newGenerations.set(batch.slotToGeneration.subarray(0, batch.count));
 
     batch.mesh = newMesh;
     batch.capacity = newCapacity;
     batch.slotToEntity = newSlots;
+    batch.slotToGeneration = newGenerations;
+    attachResolver(newMesh, batch);
   }
 
   private writeSlotTint(
@@ -406,4 +434,21 @@ function allocateInstanceColor(mesh: THREE.InstancedMesh, capacity: number): voi
   const attr = new THREE.InstancedBufferAttribute(data, 3);
   attr.setUsage(THREE.DynamicDrawUsage);
   mesh.instanceColor = attr;
+}
+
+function attachResolver(mesh: THREE.InstancedMesh, batch: Batch): void {
+  const resolver: InstancedEntityResolver = {
+    entityAt(instanceId: number): InstancedEntityRef | undefined {
+      if (!Number.isInteger(instanceId) || instanceId < 0 || instanceId >= batch.count) {
+        return undefined;
+      }
+      const entityId = batch.slotToEntity[instanceId]!;
+      if (entityId < 0) return undefined;
+      return {
+        entityId,
+        generation: batch.slotToGeneration[instanceId]!,
+      };
+    },
+  };
+  (mesh.userData as Record<PropertyKey, unknown>)[GALEON_INSTANCE_ENTITIES_KEY] = resolver;
 }

--- a/packages/three/src/renderer-cache.ts
+++ b/packages/three/src/renderer-cache.ts
@@ -211,6 +211,7 @@ export class RendererCache {
         );
         this.instancedMeshes.upsert(
           entityId,
+          generation,
           batchKey,
           geometry,
           material,


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 224
branch: issue/224-instanced-picking-identity
status: in-progress
updated_at: 2026-05-02T17:06:32Z
review_status: needs-rereview
-->

## Summary

This PR ships the identity prerequisite discovered after the instancing merges: click picking now resolves THREE.InstancedMesh raycast hits through Intersection.instanceId back to Galeon { entityId, generation } handles. It does not implement benchmarking, BVH, or GPU-readback backends; those remain the main #224 follow-up scope.

Addresses #224 (completes T0: instanced click-picking identity)

## Review Status

- **Current state:** needs re-review
- **Last reviewed by:** openai/gpt-5.5 (codex, effort: high)
- **Last reviewed at:** 2026-05-02T17:03:03Z
- **Reviewed commit:** 6d9494d317b70d4500c6daf382f1f8400fb2f445
- **Source artifact:** https://github.com/galeon-engine/galeon/pull/238#issuecomment-4364305069
- **Needs re-review since:** ac04812 fix(#224/T0): preserve visibility for instanced picks

## Completed Tasks

- [x] **T0:** Resolve instanced raycast hits back to entity identity - @galeon/three stamps instanced batches with an instance resolver and @galeon/picking consumes it for click picks.

## Remaining Tasks

- [ ] **T1:** Benchmark current picking against 100 / 1k / 10k entities.
- [ ] **T2:** Add pickingBackend option and backend-agnostic interfaces.
- [ ] **T3:** BVH backend using @three.ez/instanced-mesh for instanced meshes.
- [ ] **T4:** GPU-readback fallback for InstancedMesh.raycast first-hit limitations.

## Blocked On

- No external blocker for T0. Remaining tasks intentionally deferred to keep this PR focused on correctness before acceleration.

## Journey Timeline

### Initial Plan
#224 originally scoped performance work for large scenes, but its discovery thread noted that merged instancing PRs changed the first required step: default picking must preserve entity identity for shared instanced batches before faster backends can be meaningful.

### What We Discovered
- RendererCache correctly routes instanced entities into THREE.InstancedMesh, but those shared objects cannot carry one GALEON_ENTITY_KEY per entity.
- Three.js raycast intersections expose instanceId; Galeon needs a resolver table parallel to the instanced batch slot table.

### Implementation Issues
- Attempting to update the issue body checklist from this worktree hit a local PowerShell/tooling permission error before writing the body file. This PR body and the issue commit note capture T0 as the durable scope record.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Identity storage | Keep slot-to-entity/generation table inside InstancedMeshManager | The manager already owns swap-with-last slot placement |
| Public bridge | Export GALEON_INSTANCE_ENTITIES_KEY and resolver types from @galeon/three | @galeon/picking can resolve hits without depending on manager internals |
| Picking precedence | Resolve Intersection.instanceId before ancestor stamps | Instanced batches are shared objects; object ancestry cannot identify the hit entity |

### Changes Made

**Commits:**
- 6d9494d fix(#224/T0): resolve instanced pick hits to entities
- ac04812 fix(#224/T0): preserve visibility for instanced picks

## Testing

- [x] un install
- [x] un run check
- [x] un test packages/picking/tests/instanced-picking.test.ts
- [x] un test packages/three/tests/instanced-mesh.test.ts
- [x] git diff --check

## Knowledge for Future Reference

Future BVH/GPU picking backends should return the same { entityId, generation } shape as the default raycaster backend. For instanced objects, the canonical identity mapping is the InstancedMeshManager slot table exposed through GALEON_INSTANCE_ENTITIES_KEY.

---
Authored-by: openai/gpt-5 (codex)
Last-code-by: openai/gpt-5.5 (codex, effort: high)
Updated-by: openai/gpt-5.5 (codex, effort: high)
Edit-kind: review-snapshot
Edit-note: Recorded cross-model approving review and verification for PR #238.
Updated-by: openai/gpt-5.5 (codex, effort: high)
Edit-kind: review-snapshot
Edit-note: Marked previous approval stale after ac04812 addressed inline visibility feedback.
*Captain's log - partial delivery by [shiplog](https://github.com/devallibus/shiplog)*

