### PR TITLE
chore(#241): prepare 0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to verify (e.g. 0.4.0). Skips publish, runs verification only.'
+        description: 'Version to verify (e.g. 0.5.0). Skips publish, runs verification only.'
         required: true
 
 jobs:
@@ -210,6 +210,16 @@ jobs:
           cd packages/three
           npm publish --access public --tag "$NPM_DIST_TAG" --provenance
 
+      - name: Publish @galeon/picking
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if npm view "@galeon/picking@${version}" version >/dev/null 2>&1; then
+            echo "@galeon/picking@${version} already published; skipping."
+            exit 0
+          fi
+          cd packages/picking
+          npm publish --access public --tag "$NPM_DIST_TAG" --provenance
+
       - name: Publish @galeon/r3f
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -324,9 +334,10 @@ jobs:
             "@galeon/runtime@${VERSION}" \
             "@galeon/render-core@${VERSION}" \
             "@galeon/three@${VERSION}" \
+            "@galeon/picking@${VERSION}" \
             "@galeon/r3f@${VERSION}" \
             "@galeon/shell@${VERSION}"
-          node -e "Promise.all(['@galeon/runtime','@galeon/render-core','@galeon/three','@galeon/r3f','@galeon/shell'].map((pkg) => import(pkg))).then(() => console.log('@galeon npm packages OK'))"
+          node -e "Promise.all(['@galeon/runtime','@galeon/render-core','@galeon/three','@galeon/picking','@galeon/r3f','@galeon/shell'].map((pkg) => import(pkg))).then(() => console.log('@galeon npm packages OK'))"
 
       - name: Verify CLI — installed binary starter bootstrap
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-02
+
 ### Added
 
 - **Picking baseline benchmark (#224 / T1)** — `@galeon/picking` now includes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "galeon-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "serde",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "galeon-engine-macros",
  "inventory",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-terrain"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "galeon-engine",
  "galeon-engine-three-sync",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-three-sync"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "galeon-engine",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "AGPL-3.0-only OR LicenseRef-Commercial"
 repository = "https://github.com/galeon-engine/galeon"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ the engine itself is shell-agnostic.
 - Dynamic entity spawn/despawn from JS with `JsSpawned` lifecycle guard
 - `@galeon/render-core` defines the framework-neutral render snapshot contract
 - `@galeon/three` syncs `FramePacket` to an imperative Three.js scene graph
+- `@galeon/picking` provides mouse picking, marquee selection, and selection HUD primitives
 - `@galeon/r3f` provides React Three Fiber provider/entities/hooks
 - Generational entity safety prevents stale object references
 - Fallback geometry for missing assets
@@ -152,6 +153,7 @@ packages/
   runtime/             @galeon/runtime — JS/WASM glue (workspace + npm package)
   render-core/         @galeon/render-core — render packet contract (workspace + npm package)
   three/               @galeon/three — imperative Three.js adapter (workspace + npm package)
+  picking/             @galeon/picking — picking and selection HUD helpers (workspace + npm package)
   r3f/                 @galeon/r3f — React Three Fiber adapter (workspace + npm package)
   shell/               @galeon/shell — editor UI package (workspace + npm package, experimental)
 ```
@@ -195,14 +197,14 @@ bun run check    # Type-check all packages (tsc --build)
 
 The Bun workspace in this repository is the checked-in `packages/*` tree:
 `packages/runtime`, `packages/render-core`, `packages/three`,
-`packages/r3f`, and `packages/shell`. These are the same
+`packages/picking`, `packages/r3f`, and `packages/shell`. These are the same
 packages that publish to npm under the `@galeon/*` scope; they are not a separate
 publish-only surface outside this checkout.
 
 ## Public Packages
 
-Galeon publishes **four Rust packages** to [crates.io](https://crates.io) and
-**five TypeScript packages** to [npm](https://www.npmjs.com).
+Galeon publishes **five crates.io packages** (four libraries plus the CLI) and
+**six TypeScript packages** to [npm](https://www.npmjs.com).
 
 The TypeScript packages listed here are also checked into this repository under
 `packages/*` and are the packages targeted by the root Bun workspace commands.
@@ -213,6 +215,7 @@ The TypeScript packages listed here are also checked into this repository under
 |-------|-----------|-------------|
 | `galeon-engine-macros` | [![crates.io](https://img.shields.io/crates/v/galeon-engine-macros)](https://crates.io/crates/galeon-engine-macros) | Proc macros (`#[derive(Component)]`, `#[command]`, etc.) |
 | `galeon-engine` | [![crates.io](https://img.shields.io/crates/v/galeon-engine)](https://crates.io/crates/galeon-engine) | Core ECS, scheduler, protocol, data loading |
+| `galeon-engine-terrain` | [![crates.io](https://img.shields.io/crates/v/galeon-engine-terrain)](https://crates.io/crates/galeon-engine-terrain) | Heightmap terrain resource and loaders |
 | `galeon-engine-three-sync` | [![crates.io](https://img.shields.io/crates/v/galeon-engine-three-sync)](https://crates.io/crates/galeon-engine-three-sync) | WASM bridge (ECS snapshots &rarr; Three.js) |
 
 ### CLI binary
@@ -228,6 +231,7 @@ The TypeScript packages listed here are also checked into this repository under
 | `@galeon/runtime` | [![npm](https://img.shields.io/npm/v/@galeon/runtime)](https://www.npmjs.com/package/@galeon/runtime) | JS &harr; WASM glue |
 | `@galeon/render-core` | [![npm](https://img.shields.io/npm/v/@galeon/render-core)](https://www.npmjs.com/package/@galeon/render-core) | Framework-neutral render snapshot contract |
 | `@galeon/three` | [![npm](https://img.shields.io/npm/v/@galeon/three)](https://www.npmjs.com/package/@galeon/three) | Imperative Three.js adapter |
+| `@galeon/picking` | [![npm](https://img.shields.io/npm/v/@galeon/picking)](https://www.npmjs.com/package/@galeon/picking) | Mouse picking, marquee selection, and selection HUD primitives |
 | `@galeon/r3f` | [![npm](https://img.shields.io/npm/v/@galeon/r3f)](https://www.npmjs.com/package/@galeon/r3f) | React Three Fiber adapter |
 | `@galeon/shell` | [![npm](https://img.shields.io/npm/v/@galeon/shell)](https://www.npmjs.com/package/@galeon/shell) | Editor UI package (experimental) |
 
@@ -239,8 +243,8 @@ The following workspace members are internal and not published to any registry:
 
 ## Versioning
 
-All four Rust packages and six TypeScript packages move in **lockstep**
-&mdash; every release bumps all ten published artifacts to the same version
+All five crates.io packages and six TypeScript packages move in **lockstep**
+&mdash; every release bumps all eleven published artifacts to the same version
 number.
 
 ### Pre-1.0 policy
@@ -249,22 +253,22 @@ Galeon follows [Semantic Versioning 2.0.0](https://semver.org/). During the
 pre-1.0 phase:
 
 - **Minor bumps** (`0.3 &rarr; 0.4`) may contain breaking API changes.
-- **Patch bumps** (`0.4.0 &rarr; 0.4.1`) are backward-compatible bug fixes and
+- **Patch bumps** (`0.5.0 &rarr; 0.5.1`) are backward-compatible bug fixes and
   additions.
-- **Prerelease tags** (`0.4.0-alpha.1`, `0.4.0-beta.1`, `0.4.0-rc.1`) are
+- **Prerelease tags** (`0.5.0-alpha.1`, `0.5.0-beta.1`, `0.5.0-rc.1`) are
   published to crates.io and npm under the `alpha` dist-tag. Use these
   preview upcoming releases.
 
 ### How to depend on Galeon
 
 ```toml
-# In your Cargo.toml — matches any 0.4.x release
-galeon-engine = "0.4"
+# In your Cargo.toml — matches any 0.5.x release
+galeon-engine = "0.5"
 ```
 
 ```json
-// In your package.json — matches any 0.4.x release
-"@galeon/three": "^0.4.0"
+// In your package.json — matches any 0.5.x release
+"@galeon/three": "^0.5.0"
 ```
 
 ```bash
@@ -286,7 +290,8 @@ means for adopters:
 - `galeon-cli` is published and supported for project scaffolding, protocol
   artifact generation, and route inspection.
 - The framework-neutral render contract and both Three.js host adapters are
-  published as `@galeon/render-core`, `@galeon/three`, and `@galeon/r3f`.
+  published as `@galeon/render-core`, `@galeon/three`, `@galeon/picking`, and
+  `@galeon/r3f`.
 - The ECS, scheduler, protocol layer, and WASM bridge are functional and
   cover real use cases.
 - Lockstep versioning means all packages stay in sync &mdash; no version matrix to
@@ -298,7 +303,7 @@ means for adopters:
 - CLI commands and codegen output formats are still evolving.
 
 **How to upgrade safely:**
-- Pin to a specific minor range (e.g., `"0.4"` in Cargo, `"^0.4.0"` in npm).
+- Pin to a specific minor range (e.g., `"0.5"` in Cargo, `"^0.5.0"` in npm).
 - Read the [changelog](CHANGELOG.md) before upgrading &mdash; breaking changes are
   always documented.
 - Prerelease tags (`alpha`, `beta`, `rc`) let you test upcoming versions before

--- a/crates/engine-terrain/Cargo.toml
+++ b/crates/engine-terrain/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["galeon", "game-engine", "terrain", "heightmap"]
 categories = ["game-development"]
 
 [dependencies]
-galeon-engine = { path = "../engine", version = "=0.4.0" }
+galeon-engine = { path = "../engine", version = "=0.5.0" }
 png = { workspace = true }
 
 [dev-dependencies]
-galeon-engine-three-sync = { path = "../engine-three-sync", version = "=0.4.0" }
+galeon-engine-three-sync = { path = "../engine-three-sync", version = "=0.5.0" }

--- a/crates/engine-three-sync/Cargo.toml
+++ b/crates/engine-three-sync/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-development", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-galeon-engine = { path = "../engine", version = "=0.4.0" }
+galeon-engine = { path = "../engine", version = "=0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["galeon", "ecs", "game-engine", "entity"]
 categories = ["game-development"]
 
 [dependencies]
-galeon-engine-macros = { path = "../engine-macros", version = "=0.4.0" }
+galeon-engine-macros = { path = "../engine-macros", version = "=0.5.0" }
 inventory = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -4,8 +4,9 @@
 > to install and what stability to expect. This guide covers the release
 > procedure for maintainers.
 
-Galeon publishes **five Rust packages** to crates.io and **five TypeScript
-packages** to npm. Everything else in the workspace is internal.
+Galeon publishes **five crates.io packages** (four libraries plus the CLI) and
+**six TypeScript packages** to npm. Everything else in the workspace is
+internal.
 
 The npm packages in this guide are the checked-in workspace packages under
 `packages/*`. They are not a separate external-only package surface.
@@ -34,8 +35,9 @@ The npm packages in this guide are the checked-in workspace packages under
 | Runtime | `@galeon/runtime` | 1 — publish first |
 | Render core | `@galeon/render-core` | 2 — framework-neutral render contract |
 | Three adapter | `@galeon/three` | 3 — depends on render-core |
-| R3F adapter | `@galeon/r3f` | 4 — depends on render-core/three |
-| Shell | `@galeon/shell` | 5 — no deps, last by convention |
+| Picking | `@galeon/picking` | 4 — depends on three |
+| R3F adapter | `@galeon/r3f` | 5 — depends on render-core/three/picking |
+| Shell | `@galeon/shell` | 6 — no deps, last by convention |
 
 ### Not published
 
@@ -43,9 +45,9 @@ The npm packages in this guide are the checked-in workspace packages under
 
 ## Versioning
 
-All five Rust packages and all TypeScript packages move in **lockstep**. The Rust
-workspace version lives in `Cargo.toml` → `[workspace.package] version` and is
-inherited by publishable crates via `version.workspace = true`, including
+All five crates.io packages and six TypeScript packages move in **lockstep**.
+The Rust workspace version lives in `Cargo.toml` → `[workspace.package] version`
+and is inherited by publishable crates via `version.workspace = true`, including
 `galeon-cli`. npm package versions are kept in sync manually. Internal
 dependencies use exact pins (`=X.Y.Z`) to enforce lockstep.
 
@@ -57,35 +59,37 @@ Run the bump script from the repo root:
 bash scripts/bump-version.sh A.B.C
 ```
 
-This updates Galeon's shared version sources (12 edits across 9 files) after
+This updates Galeon's shared version sources (19 edits across 11 files) after
 verifying the current versions are consistent, and rolls back if verification
 fails. `galeon-cli` inherits the workspace version automatically, so it does not
 need a separate version edit.
 The script supports prerelease and build metadata tags
-(`0.4.0-alpha.1`, `0.4.0-alpha-1+build-7`).
+(`0.5.0-alpha.1`, `0.5.0-alpha-1+build-7`).
 
 The script edits these locations:
 
 1. `Cargo.toml` → `[workspace.package] version = "A.B.C"`
 2. `crates/engine/Cargo.toml` → `galeon-engine-macros = { …, version = "=A.B.C" }`
-3. `crates/engine-terrain/Cargo.toml` → `galeon-engine = { …, version = "=A.B.C" }`
+3. `crates/engine-terrain/Cargo.toml` → `galeon-engine = { …, version = "=A.B.C" }` and its `galeon-engine-three-sync` dev-dependency pin
 4. `crates/engine-three-sync/Cargo.toml` → `galeon-engine = { …, version = "=A.B.C" }`
 5. `packages/runtime/package.json` → `"version": "A.B.C"`
 6. `packages/render-core/package.json` → `"version": "A.B.C"`
 7. `packages/three/package.json` → `"version": "A.B.C"` **and** `"@galeon/render-core": "=A.B.C"`
-8. `packages/r3f/package.json` → `"version": "A.B.C"` **and** exact `@galeon/*` pins
-9. `packages/shell/package.json` → `"version": "A.B.C"`
+8. `packages/picking/package.json` → `"version": "A.B.C"` **and** `"@galeon/three": "=A.B.C"`
+9. `packages/r3f/package.json` → `"version": "A.B.C"` **and** exact `@galeon/*` pins
+10. `packages/shell/package.json` → `"version": "A.B.C"`
+11. `examples/instanced-cubes/package.json` → package version and exact `@galeon/*` pins used by the checked-in example
 
 After running, manually update the changelog:
 
-10. `CHANGELOG.md` → move `## Unreleased` items under `## [A.B.C]`
+12. `CHANGELOG.md` → move `## Unreleased` items under `## [A.B.C]`
 
 ## Path dependencies and versions (Rust)
 
 Workspace crates use **path + pinned version**:
 
 ```toml
-galeon-engine-macros = { path = "../engine-macros", version = "=0.4.0" }
+galeon-engine-macros = { path = "../engine-macros", version = "=0.5.0" }
 ```
 
 Cargo strips `path` for published tarballs.
@@ -116,6 +120,7 @@ bunx tsc --build                           # Build JS + declarations
 npm pack --dry-run --workspace=packages/runtime
 npm pack --dry-run --workspace=packages/render-core
 npm pack --dry-run --workspace=packages/three
+npm pack --dry-run --workspace=packages/picking
 npm pack --dry-run --workspace=packages/r3f
 npm pack --dry-run --workspace=packages/shell
 ```
@@ -163,6 +168,7 @@ npm login
 cd packages/runtime    && npm publish --access public && cd ../..
 cd packages/render-core && npm publish --access public && cd ../..
 cd packages/three      && npm publish --access public && cd ../..
+cd packages/picking    && npm publish --access public && cd ../..
 cd packages/r3f        && npm publish --access public && cd ../..
 cd packages/shell      && npm publish --access public && cd ../..
 ```
@@ -194,14 +200,15 @@ OIDC provenance from GitHub Actions — no token needed.
 
 ## Consumer guidance
 
-Galeon is pre-1.0. All ten published artifacts move in lockstep &mdash; pick a
+Galeon is pre-1.0. All eleven published artifacts move in lockstep &mdash; pick a
 minor version and pin to it. Read the [changelog](../../CHANGELOG.md) on each
 upgrade.
 
 - Core engine crates are published and intended for evaluation and early use.
 - `galeon-cli` is the supported install surface for scaffolding and codegen.
-- `@galeon/render-core`, `@galeon/three`, and `@galeon/r3f` are the supported
-  render adapter packages. The legacy `@galeon/engine-ts` compatibility
+- `@galeon/render-core`, `@galeon/three`, `@galeon/picking`, and `@galeon/r3f`
+  are the supported render and picking adapter packages. The legacy
+  `@galeon/engine-ts` compatibility
   re-export package was retired in `0.5.0` (see issue #209); previously
   published versions remain installable on npm but no further releases will
   be cut from this repo.

--- a/examples/instanced-cubes/package.json
+++ b/examples/instanced-cubes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/example-instanced-cubes",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "5000-cube benchmark exercising the GPU-instanced render path",
   "type": "module",
@@ -10,8 +10,8 @@
     "start": "bun build src/main.ts --outdir=dist --target=browser --format=esm --watch"
   },
   "dependencies": {
-    "@galeon/render-core": "=0.4.0",
-    "@galeon/three": "=0.4.0",
+    "@galeon/render-core": "=0.5.0",
+    "@galeon/three": "=0.5.0",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/picking/package.json
+++ b/packages/picking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/picking",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Mouse picking and drag-rectangle selection helper for Galeon scenes",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/three": "=0.4.0",
+    "@galeon/three": "=0.5.0",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/r3f/package.json
+++ b/packages/r3f/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/r3f",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React Three Fiber adapter for Galeon render snapshots",
   "type": "module",
   "main": "dist/index.js",
@@ -23,9 +23,9 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/picking": "=0.4.0",
-    "@galeon/render-core": "=0.4.0",
-    "@galeon/three": "=0.4.0"
+    "@galeon/picking": "=0.5.0",
+    "@galeon/render-core": "=0.5.0",
+    "@galeon/three": "=0.5.0"
   },
   "devDependencies": {
     "@react-three/fiber": "^9.6.1",

--- a/packages/render-core/package.json
+++ b/packages/render-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/render-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Framework-neutral Galeon render snapshot contract and packet guardrails",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/runtime",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Galeon Engine runtime — thin JS↔WASM invoke/events bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/shell",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Galeon Engine editor shell — Godot-style Solid.js panel UI",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/three",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Imperative Three.js adapter for Galeon render snapshots",
   "type": "module",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/render-core": "=0.4.0",
+    "@galeon/render-core": "=0.5.0",
     "@three.ez/instanced-mesh": "0.3.15",
     "three": "^0.183.2"
   },

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only OR Commercial
 #
-# bump-version.sh — Update the shared version sources for Galeon's 10 lockstep published artifacts.
+# bump-version.sh — Update the shared version sources for Galeon's 11 lockstep published artifacts.
 #
 # Usage: scripts/bump-version.sh X.Y.Z
 #
 # Validates semver format, checks current versions are consistent,
-# then updates all versioned locations across 9 files. `galeon-cli`
+# then updates all versioned locations across 11 files. `galeon-cli`
 # inherits the workspace version, so it needs no separate bump file.
 # Fails fast on any inconsistency or missing file.
 
@@ -56,7 +56,7 @@ NEW_VERSION="${1:-}"
 if [[ -z "$NEW_VERSION" ]]; then
   echo "Usage: scripts/bump-version.sh X.Y.Z"
   echo ""
-  echo "Updates Galeon's shared version sources (12 edits across 9 files)."
+  echo "Updates Galeon's shared version sources (19 edits across 11 files)."
   exit 1
 fi
 
@@ -79,8 +79,10 @@ THREE_SYNC_CARGO="crates/engine-three-sync/Cargo.toml"
 RUNTIME_PKG="packages/runtime/package.json"
 RENDER_CORE_PKG="packages/render-core/package.json"
 THREE_PKG="packages/three/package.json"
+PICKING_PKG="packages/picking/package.json"
 R3F_PKG="packages/r3f/package.json"
 SHELL_PKG="packages/shell/package.json"
+INSTANCED_CUBES_PKG="examples/instanced-cubes/package.json"
 
 ALL_FILES=(
   "$WORKSPACE_CARGO"
@@ -90,8 +92,10 @@ ALL_FILES=(
   "$RUNTIME_PKG"
   "$RENDER_CORE_PKG"
   "$THREE_PKG"
+  "$PICKING_PKG"
   "$R3F_PKG"
   "$SHELL_PKG"
+  "$INSTANCED_CUBES_PKG"
 )
 
 # ── Check all files exist ───────────────────────────────────────────
@@ -112,17 +116,27 @@ CURRENT=$(sed -n '/\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"/\1/p}' 
 ok "$WORKSPACE_CARGO  workspace.package.version = $CURRENT"
 
 # 2. engine dep on macros
-V_ENGINE_MACROS=$(sed -n 's/^galeon-engine-macros.*version *= *"=\([^"]*\)".*/\1/p' "$ENGINE_CARGO" | strip_cr)
+read_cargo_dep_pin() {
+  local file="$1"
+  local dep="$2"
+  sed -n "s/^${dep}[[:space:]]*=.*version *= *\"=\\([^\"]*\\)\".*/\\1/p" "$file" | strip_cr
+}
+
+V_ENGINE_MACROS=$(read_cargo_dep_pin "$ENGINE_CARGO" "galeon-engine-macros")
 [[ -n "$V_ENGINE_MACROS" ]] || die "Cannot read galeon-engine-macros pin from $ENGINE_CARGO"
 ok "$ENGINE_CARGO  galeon-engine-macros = =$V_ENGINE_MACROS"
 
 # 3. terrain dep on engine
-V_TERRAIN_ENGINE=$(sed -n 's/^galeon-engine.*version *= *"=\([^"]*\)".*/\1/p' "$TERRAIN_CARGO" | strip_cr)
+V_TERRAIN_ENGINE=$(read_cargo_dep_pin "$TERRAIN_CARGO" "galeon-engine")
 [[ -n "$V_TERRAIN_ENGINE" ]] || die "Cannot read galeon-engine pin from $TERRAIN_CARGO"
 ok "$TERRAIN_CARGO  galeon-engine = =$V_TERRAIN_ENGINE"
 
+V_TERRAIN_THREE_SYNC=$(read_cargo_dep_pin "$TERRAIN_CARGO" "galeon-engine-three-sync")
+[[ -n "$V_TERRAIN_THREE_SYNC" ]] || die "Cannot read galeon-engine-three-sync pin from $TERRAIN_CARGO"
+ok "$TERRAIN_CARGO  galeon-engine-three-sync = =$V_TERRAIN_THREE_SYNC"
+
 # 4. three-sync dep on engine
-V_THREE_ENGINE=$(sed -n 's/^galeon-engine.*version *= *"=\([^"]*\)".*/\1/p' "$THREE_SYNC_CARGO" | strip_cr)
+V_THREE_ENGINE=$(read_cargo_dep_pin "$THREE_SYNC_CARGO" "galeon-engine")
 [[ -n "$V_THREE_ENGINE" ]] || die "Cannot read galeon-engine pin from $THREE_SYNC_CARGO"
 ok "$THREE_SYNC_CARGO  galeon-engine = =$V_THREE_ENGINE"
 
@@ -153,9 +167,21 @@ V_THREE_RENDER_CORE=$(read_pkg_dep_pin "$THREE_PKG" "@galeon/render-core")
 [[ -n "$V_THREE_RENDER_CORE" ]] || die "Cannot read @galeon/render-core pin from $THREE_PKG"
 ok "$THREE_PKG  @galeon/render-core = =$V_THREE_RENDER_CORE"
 
+V_PICKING=$(read_pkg_version "$PICKING_PKG")
+[[ -n "$V_PICKING" ]] || die "Cannot read version from $PICKING_PKG"
+ok "$PICKING_PKG  version = $V_PICKING"
+
+V_PICKING_THREE=$(read_pkg_dep_pin "$PICKING_PKG" "@galeon/three")
+[[ -n "$V_PICKING_THREE" ]] || die "Cannot read @galeon/three pin from $PICKING_PKG"
+ok "$PICKING_PKG  @galeon/three = =$V_PICKING_THREE"
+
 V_R3F=$(read_pkg_version "$R3F_PKG")
 [[ -n "$V_R3F" ]] || die "Cannot read version from $R3F_PKG"
 ok "$R3F_PKG  version = $V_R3F"
+
+V_R3F_PICKING=$(read_pkg_dep_pin "$R3F_PKG" "@galeon/picking")
+[[ -n "$V_R3F_PICKING" ]] || die "Cannot read @galeon/picking pin from $R3F_PKG"
+ok "$R3F_PKG  @galeon/picking = =$V_R3F_PICKING"
 
 V_R3F_RENDER_CORE=$(read_pkg_dep_pin "$R3F_PKG" "@galeon/render-core")
 [[ -n "$V_R3F_RENDER_CORE" ]] || die "Cannot read @galeon/render-core pin from $R3F_PKG"
@@ -168,6 +194,18 @@ ok "$R3F_PKG  @galeon/three = =$V_R3F_THREE"
 V_SHELL=$(read_pkg_version "$SHELL_PKG")
 [[ -n "$V_SHELL" ]] || die "Cannot read version from $SHELL_PKG"
 ok "$SHELL_PKG  version = $V_SHELL"
+
+V_INSTANCED_CUBES_RENDER_CORE=$(read_pkg_dep_pin "$INSTANCED_CUBES_PKG" "@galeon/render-core")
+[[ -n "$V_INSTANCED_CUBES_RENDER_CORE" ]] || die "Cannot read @galeon/render-core pin from $INSTANCED_CUBES_PKG"
+ok "$INSTANCED_CUBES_PKG  @galeon/render-core = =$V_INSTANCED_CUBES_RENDER_CORE"
+
+V_INSTANCED_CUBES=$(read_pkg_version "$INSTANCED_CUBES_PKG")
+[[ -n "$V_INSTANCED_CUBES" ]] || die "Cannot read version from $INSTANCED_CUBES_PKG"
+ok "$INSTANCED_CUBES_PKG  version = $V_INSTANCED_CUBES"
+
+V_INSTANCED_CUBES_THREE=$(read_pkg_dep_pin "$INSTANCED_CUBES_PKG" "@galeon/three")
+[[ -n "$V_INSTANCED_CUBES_THREE" ]] || die "Cannot read @galeon/three pin from $INSTANCED_CUBES_PKG"
+ok "$INSTANCED_CUBES_PKG  @galeon/three = =$V_INSTANCED_CUBES_THREE"
 echo ""
 
 # ── Consistency check ────────────────────────────────────────────────
@@ -177,15 +215,22 @@ ALL_VERSIONS=(
   "$CURRENT"
   "$V_ENGINE_MACROS"
   "$V_TERRAIN_ENGINE"
+  "$V_TERRAIN_THREE_SYNC"
   "$V_THREE_ENGINE"
   "$V_RUNTIME"
   "$V_RENDER_CORE"
   "$V_THREE"
   "$V_THREE_RENDER_CORE"
+  "$V_PICKING"
+  "$V_PICKING_THREE"
   "$V_R3F"
+  "$V_R3F_PICKING"
   "$V_R3F_RENDER_CORE"
   "$V_R3F_THREE"
   "$V_SHELL"
+  "$V_INSTANCED_CUBES"
+  "$V_INSTANCED_CUBES_RENDER_CORE"
+  "$V_INSTANCED_CUBES_THREE"
 )
 
 for v in "${ALL_VERSIONS[@]}"; do
@@ -193,7 +238,7 @@ for v in "${ALL_VERSIONS[@]}"; do
     die "Version mismatch! Expected all to be '$CURRENT' but found '$v'. Fix manually before bumping."
   fi
 done
-ok "All 12 locations currently at $CURRENT"
+ok "All 19 locations currently at $CURRENT"
 echo ""
 
 # ── No-op check ─────────────────────────────────────────────────────
@@ -246,15 +291,27 @@ sed -i "s/\"version\": \"$OLD_ESC\"/\"version\": \"$NEW_VERSION\"/" "$THREE_PKG"
 sed -i "s/\"@galeon\/render-core\": \"=$OLD_ESC\"/\"@galeon\/render-core\": \"=$NEW_VERSION\"/" "$THREE_PKG"
 ok "$THREE_PKG"
 
-# 8. r3f package.json (version + internal deps)
+# 8. picking package.json (version + three dep)
+sed -i "s/\"version\": \"$OLD_ESC\"/\"version\": \"$NEW_VERSION\"/" "$PICKING_PKG"
+sed -i "s/\"@galeon\/three\": \"=$OLD_ESC\"/\"@galeon\/three\": \"=$NEW_VERSION\"/" "$PICKING_PKG"
+ok "$PICKING_PKG"
+
+# 9. r3f package.json (version + internal deps)
 sed -i "s/\"version\": \"$OLD_ESC\"/\"version\": \"$NEW_VERSION\"/" "$R3F_PKG"
+sed -i "s/\"@galeon\/picking\": \"=$OLD_ESC\"/\"@galeon\/picking\": \"=$NEW_VERSION\"/" "$R3F_PKG"
 sed -i "s/\"@galeon\/render-core\": \"=$OLD_ESC\"/\"@galeon\/render-core\": \"=$NEW_VERSION\"/" "$R3F_PKG"
 sed -i "s/\"@galeon\/three\": \"=$OLD_ESC\"/\"@galeon\/three\": \"=$NEW_VERSION\"/" "$R3F_PKG"
 ok "$R3F_PKG"
 
-# 9. shell package.json
+# 10. shell package.json
 sed -i "s/\"version\": \"$OLD_ESC\"/\"version\": \"$NEW_VERSION\"/" "$SHELL_PKG"
 ok "$SHELL_PKG"
+
+# 11. example package.json internal deps
+sed -i "s/\"version\": \"$OLD_ESC\"/\"version\": \"$NEW_VERSION\"/" "$INSTANCED_CUBES_PKG"
+sed -i "s/\"@galeon\/render-core\": \"=$OLD_ESC\"/\"@galeon\/render-core\": \"=$NEW_VERSION\"/" "$INSTANCED_CUBES_PKG"
+sed -i "s/\"@galeon\/three\": \"=$OLD_ESC\"/\"@galeon\/three\": \"=$NEW_VERSION\"/" "$INSTANCED_CUBES_PKG"
+ok "$INSTANCED_CUBES_PKG"
 
 echo ""
 
@@ -276,15 +333,22 @@ verify() {
 verify "$WORKSPACE_CARGO"   "version = \"$NEW_VERSION\""            "workspace version"
 verify "$ENGINE_CARGO"       "version = \"=$NEW_VERSION\""           "macros pin"
 verify "$TERRAIN_CARGO"      "version = \"=$NEW_VERSION\""           "engine pin"
+verify "$TERRAIN_CARGO"      "galeon-engine-three-sync = { path = \"../engine-three-sync\", version = \"=$NEW_VERSION\" }" "three-sync pin"
 verify "$THREE_SYNC_CARGO"   "version = \"=$NEW_VERSION\""           "engine pin"
 verify "$RUNTIME_PKG"        "\"version\": \"$NEW_VERSION\""         "runtime version"
 verify "$RENDER_CORE_PKG"    "\"version\": \"$NEW_VERSION\""         "render-core version"
 verify "$THREE_PKG"          "\"version\": \"$NEW_VERSION\""         "three version"
 verify "$THREE_PKG"          "\"@galeon/render-core\": \"=$NEW_VERSION\"" "three render-core pin"
+verify "$PICKING_PKG"        "\"version\": \"$NEW_VERSION\""         "picking version"
+verify "$PICKING_PKG"        "\"@galeon/three\": \"=$NEW_VERSION\""  "picking three pin"
 verify "$R3F_PKG"            "\"version\": \"$NEW_VERSION\""         "r3f version"
+verify "$R3F_PKG"            "\"@galeon/picking\": \"=$NEW_VERSION\"" "r3f picking pin"
 verify "$R3F_PKG"            "\"@galeon/render-core\": \"=$NEW_VERSION\"" "r3f render-core pin"
 verify "$R3F_PKG"            "\"@galeon/three\": \"=$NEW_VERSION\""  "r3f three pin"
 verify "$SHELL_PKG"          "\"version\": \"$NEW_VERSION\""         "shell version"
+verify "$INSTANCED_CUBES_PKG" "\"version\": \"$NEW_VERSION\"" "instanced-cubes version"
+verify "$INSTANCED_CUBES_PKG" "\"@galeon/render-core\": \"=$NEW_VERSION\"" "instanced-cubes render-core pin"
+verify "$INSTANCED_CUBES_PKG" "\"@galeon/three\": \"=$NEW_VERSION\"" "instanced-cubes three pin"
 
 if [[ $ERRORS -gt 0 ]]; then
   die "$ERRORS verification(s) failed. Check the files manually."
@@ -293,7 +357,7 @@ fi
 ROLLBACK_NEEDED=0
 
 echo ""
-echo "Done. All 12 locations updated to $NEW_VERSION."
+echo "Done. All 19 locations updated to $NEW_VERSION."
 echo ""
 echo "Next steps:"
 echo "  1. Update CHANGELOG.md (move Unreleased items under ## [$NEW_VERSION])"

--- a/tests/local-first-starter-smoke.sh
+++ b/tests/local-first-starter-smoke.sh
@@ -93,6 +93,34 @@ normalize_file_dep_path() {
   printf '%s\n' "$path"
 }
 
+escape_pwsh_single_quoted() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+run_galeon_in_project() {
+  if uses_windows_paths "$GALEON_BIN"; then
+    local project_dir_tool
+    local galeon_bin_tool
+    local command
+    local arg
+    local encoded_command
+
+    project_dir_tool="$(normalize_path_for_tool "$PROJECT_DIR" "$GALEON_BIN")"
+    galeon_bin_tool="$(normalize_path_for_tool "$GALEON_BIN" "$GALEON_BIN")"
+    command="\$ProgressPreference = 'SilentlyContinue'; Set-Location -LiteralPath '$(escape_pwsh_single_quoted "$project_dir_tool")'; & '$(escape_pwsh_single_quoted "$galeon_bin_tool")'"
+
+    for arg in "$@"; do
+      command="$command '$(escape_pwsh_single_quoted "$arg")'"
+    done
+
+    encoded_command="$(printf '%s' "$command" | iconv -f UTF-8 -t UTF-16LE | base64 | tr -d '\n')"
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand "$encoded_command"
+    return
+  fi
+
+  (cd "$PROJECT_DIR" && "$GALEON_BIN" "$@")
+}
+
 CARGO_BIN="$(find_tool cargo)"
 BUN_BIN="$(find_tool bun)"
 INSTALL_ROOT_TOOL="$(normalize_path_for_tool "$INSTALL_ROOT" "$CARGO_BIN")"
@@ -145,12 +173,13 @@ replace_line_in_file() {
   local file="$1"
   local prefix="$2"
   local replacement="$3"
+  local file_tool
 
-  FILE="$file" PREFIX="$prefix" REPLACEMENT="$replacement" "$BUN_BIN" -e '
+  file_tool="$(normalize_path_for_tool "$file" "$BUN_BIN")"
+
+  "$BUN_BIN" -e '
 const fs = require("node:fs");
-const file = process.env.FILE;
-const prefix = process.env.PREFIX;
-const replacement = process.env.REPLACEMENT;
+const [file, prefix, replacement] = process.argv.slice(1);
 const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
 let found = false;
 const updated = lines.map((line) => {
@@ -165,22 +194,24 @@ if (!found) {
   process.exit(1);
 }
 fs.writeFileSync(file, `${updated.join("\n").replace(/\n*$/, "\n")}`);
-'
+' "$file_tool" "$prefix" "$replacement"
 }
 
 assert_file_contains() {
   local file="$1"
   local snippet="$2"
+  local file_tool
 
-  FILE="$file" SNIPPET="$snippet" "$BUN_BIN" -e '
+  file_tool="$(normalize_path_for_tool "$file" "$BUN_BIN")"
+
+  "$BUN_BIN" -e '
 const fs = require("node:fs");
-const file = process.env.FILE;
-const snippet = process.env.SNIPPET;
+const [file, snippet] = process.argv.slice(1);
 if (!fs.readFileSync(file, "utf8").includes(snippet)) {
   console.error(`expected ${file} to contain ${snippet}`);
   process.exit(1);
 }
-'
+' "$file_tool" "$snippet"
 }
 
 configure_source_mode_scaffold() {
@@ -215,16 +246,9 @@ configure_source_mode_scaffold() {
     "galeon-engine-three-sync = " \
     "galeon-engine-three-sync = { path = \"$THREE_SYNC_CRATE_DEP_PATH\" }"
 
-  PACKAGE_JSON="$PROJECT_DIR/package.json" \
-  RUNTIME_FILE_DEP="file:$RUNTIME_PACKAGE_DEP_PATH" \
-  RENDER_CORE_FILE_DEP="file:$RENDER_CORE_PACKAGE_DEP_PATH" \
-  THREE_FILE_DEP="file:$THREE_PACKAGE_DEP_PATH" \
   "$BUN_BIN" -e '
 const fs = require("node:fs");
-const file = process.env.PACKAGE_JSON;
-const runtime = process.env.RUNTIME_FILE_DEP;
-const renderCore = process.env.RENDER_CORE_FILE_DEP;
-const three = process.env.THREE_FILE_DEP;
+const [file, runtime, renderCore, three] = process.argv.slice(1);
 const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
 pkg.dependencies["@galeon/render-core"] = renderCore;
 pkg.dependencies["@galeon/three"] = three;
@@ -235,7 +259,11 @@ pkg.overrides["@galeon/runtime"] = runtime;
 pkg.overrides["@galeon/render-core"] = renderCore;
 pkg.overrides["@galeon/three"] = three;
 fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
-'
+' \
+    "$(normalize_path_for_tool "$PROJECT_DIR/package.json" "$BUN_BIN")" \
+    "file:$RUNTIME_PACKAGE_DEP_PATH" \
+    "file:$RENDER_CORE_PACKAGE_DEP_PATH" \
+    "file:$THREE_PACKAGE_DEP_PATH"
 
   assert_file_contains "$PROJECT_DIR/crates/protocol/Cargo.toml" 'galeon-engine = { path = "'
   assert_file_contains "$PROJECT_DIR/crates/client/Cargo.toml" 'galeon-engine-three-sync = { path = "'
@@ -261,8 +289,9 @@ popd >/dev/null
 
 configure_source_mode_scaffold
 
+run_galeon_in_project generate manifest >/dev/null
+
 pushd "$PROJECT_DIR" >/dev/null
-"$GALEON_BIN" generate manifest >/dev/null
 test -f generated/manifest.json
 "$BUN_BIN" install
 "$BUN_BIN" run check


### PR DESCRIPTION
<!-- shiplog:
kind: pr
issue: 241
status: review
phase: 2
readiness: ready
-->

## Summary

- Bump Galeon workspace/package metadata to `0.5.0` and add the dated changelog section.
- Add `@galeon/picking` to the npm release workflow, verification install/import, version bump script, README package matrix, and publishing guide.
- Extend the bump script to cover terrain/three-sync pins, picking, R3F picking pins, and the checked-in instanced-cubes example.
- Harden `tests/local-first-starter-smoke.sh` for source-installed Windows tools from WSL/Git Bash by passing normalized paths as tool arguments and running the Windows CLI from a Windows project cwd.

## Shiplog

Addresses #241. T1-T5 are complete; T6 remains open for tagging and monitoring `v0.5.0` after this PR merges.

## Verification

- `bun install`
- `cargo check --workspace`
- `bun run check`
- `cargo test --workspace`
- `cargo fmt --check`
- `bash tests/release-workflow-logic.sh`
- `npm pack --dry-run --workspace=packages/runtime`
- `npm pack --dry-run --workspace=packages/render-core`
- `npm pack --dry-run --workspace=packages/three`
- `npm pack --dry-run --workspace=packages/picking`
- `npm pack --dry-run --workspace=packages/r3f`
- `npm pack --dry-run --workspace=packages/shell`
- `bash tests/local-first-starter-smoke.sh`
- `bash scripts/bump-version.sh 0.5.0` no-op consistency check, expected to stop because the tree is already at `0.5.0`
- `cargo publish -p galeon-engine-macros --dry-run --allow-dirty`

Note: downstream Rust `cargo publish --dry-run` checks that depend on exact `=0.5.0` unpublished crates are expected to fail until the upstream package exists in the crates.io index. The release workflow publishes in dependency order and has propagation retries for that path.
