### PR TITLE
ci(#241): recover 0.5.0 release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - run: npm pack --dry-run --workspace=packages/runtime
       - run: npm pack --dry-run --workspace=packages/render-core
       - run: npm pack --dry-run --workspace=packages/three
+      - run: npm pack --dry-run --workspace=packages/picking
       - run: npm pack --dry-run --workspace=packages/r3f
       - run: npm pack --dry-run --workspace=packages/shell
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,31 +95,6 @@ jobs:
           echo "Timed out waiting for galeon-engine-macros dependency."
           exit 1
 
-      - name: Publish galeon-engine-terrain
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          for attempt in $(seq 1 30); do
-            set +e
-            output="$(cargo publish -p galeon-engine-terrain 2>&1)"
-            status=$?
-            set -e
-            echo "$output"
-            if [ $status -eq 0 ]; then exit 0; fi
-            if [[ "$output" == *"already exists on crates.io index"* ]]; then
-              echo "galeon-engine-terrain v${VERSION} already published; skipping."
-              exit 0
-            fi
-            if [[ "$output" == *"failed to select a version"* ]] && [[ "$output" == *"galeon-engine"* ]]; then
-              echo "galeon-engine still propagating (attempt ${attempt}/30). Waiting 10s..."
-              sleep 10
-              continue
-            fi
-            exit $status
-          done
-          echo "Timed out waiting for galeon-engine dependency."
-          exit 1
-
       - name: Publish galeon-engine-three-sync
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -143,6 +118,31 @@ jobs:
             exit $status
           done
           echo "Timed out waiting for galeon-engine dependency."
+          exit 1
+
+      - name: Publish galeon-engine-terrain
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          for attempt in $(seq 1 30); do
+            set +e
+            output="$(cargo publish -p galeon-engine-terrain 2>&1)"
+            status=$?
+            set -e
+            echo "$output"
+            if [ $status -eq 0 ]; then exit 0; fi
+            if [[ "$output" == *"already exists on crates.io index"* ]]; then
+              echo "galeon-engine-terrain v${VERSION} already published; skipping."
+              exit 0
+            fi
+            if [[ "$output" == *"failed to select a version"* ]] && [[ "$output" == *"galeon-engine-three-sync"* ]]; then
+              echo "galeon-engine-three-sync still propagating (attempt ${attempt}/30). Waiting 10s..."
+              sleep 10
+              continue
+            fi
+            exit $status
+          done
+          echo "Timed out waiting for galeon-engine-three-sync dependency."
           exit 1
 
   publish-npm:


### PR DESCRIPTION
<!-- shiplog:
kind: pr
issue: 241
status: review
phase: 3
readiness: recovery
-->

## Summary

- Add `packages/picking` to the shared CI npm pack dry-run list.
- Publish `galeon-engine-three-sync` before `galeon-engine-terrain` in the Release workflow, matching terrain's exact dev-dependency on three-sync.
- Update the terrain retry message to wait on three-sync propagation instead of engine propagation.

## Release Recovery Context

The first `v0.5.0` tag run published these artifacts before failing:

- crates.io: `galeon-engine-macros@0.5.0`, `galeon-engine@0.5.0`
- npm: `@galeon/runtime@0.5.0`, `@galeon/render-core@0.5.0`, `@galeon/three@0.5.0`

It failed on:

- `galeon-engine-terrain`, because `galeon-engine-three-sync@0.5.0` was not published yet.
- `@galeon/picking`, because npm returned `E404` for first publish under the `@galeon` scope. That is an npm package/trusted-publisher permission issue, not a tarball/build issue.

After this merges, recovery is: update the `v0.5.0` tag to the fixed `master` commit and rerun the Release workflow. Already-published artifacts are idempotently skipped by existing checks.

## Verification

- `bash tests/release-workflow-logic.sh`

Addresses #241 T6 recovery.
