### PR TITLE
ci(#241): decouple independent release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,16 @@ jobs:
           cd packages/three
           npm publish --access public --tag "$NPM_DIST_TAG" --provenance
 
+      - name: Publish @galeon/shell
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if npm view "@galeon/shell@${version}" version >/dev/null 2>&1; then
+            echo "@galeon/shell@${version} already published; skipping."
+            exit 0
+          fi
+          cd packages/shell
+          npm publish --access public --tag "$NPM_DIST_TAG" --provenance
+
       - name: Publish @galeon/picking
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -230,19 +240,9 @@ jobs:
           cd packages/r3f
           npm publish --access public --tag "$NPM_DIST_TAG" --provenance
 
-      - name: Publish @galeon/shell
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          if npm view "@galeon/shell@${version}" version >/dev/null 2>&1; then
-            echo "@galeon/shell@${version} already published; skipping."
-            exit 0
-          fi
-          cd packages/shell
-          npm publish --access public --tag "$NPM_DIST_TAG" --provenance
-
   publish-cli:
     if: github.event_name != 'workflow_dispatch'
-    needs: [publish-crates, publish-npm]
+    needs: publish-crates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- shiplog:
kind: pr
issue: 241
status: review
phase: 3
readiness: recovery
-->

## Summary

- Publish independent `@galeon/shell` before the blocked `@galeon/picking` package.
- Let `publish-cli` depend only on successful Rust crate publication instead of the npm job.

## Recovery Context

The fixed `v0.5.0` retry published all Rust library crates, but npm still cannot first-publish `@galeon/picking` and that prevented both `@galeon/shell` and `galeon-cli` from publishing. This keeps independent artifacts moving while preserving the final release verification gate: the Release workflow still fails until npm `@galeon/picking` / `@galeon/r3f` publish successfully.

## Verification

- `bash tests/release-workflow-logic.sh`

Addresses #241 T6 recovery.
