### PR TITLE
ci(#241): use npm token for release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- shiplog:
kind: pr
issue: 241
status: review
phase: 3
readiness: recovery
-->

## Summary

- Pass the repo `NPM_TOKEN` secret to the Release workflow npm publish job as `NODE_AUTH_TOKEN`.

## Context

Trusted publishing still cannot first-publish `@galeon/picking` under the `@galeon` scope. A one-time npm token was added as the repo secret `NPM_TOKEN` for release recovery. Existing package publish steps stay idempotent and will skip packages already at `0.5.0`.

## Verification

- `bash tests/release-workflow-logic.sh`

Addresses #241 T6 recovery.
