### PR TITLE
chore(#248): prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-03
+
 ### Changed
 
 - **CLI scaffold engine pin auto-tracks engine package (#246)** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "galeon-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "serde",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "galeon-engine-macros",
  "inventory",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-terrain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "galeon-engine",
  "galeon-engine-three-sync",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "galeon-engine-three-sync"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "galeon-engine",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "AGPL-3.0-only OR LicenseRef-Commercial"
 repository = "https://github.com/galeon-engine/galeon"

--- a/crates/engine-terrain/Cargo.toml
+++ b/crates/engine-terrain/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["galeon", "game-engine", "terrain", "heightmap"]
 categories = ["game-development"]
 
 [dependencies]
-galeon-engine = { path = "../engine", version = "=0.5.0" }
+galeon-engine = { path = "../engine", version = "=0.5.1" }
 png = { workspace = true }
 
 [dev-dependencies]
-galeon-engine-three-sync = { path = "../engine-three-sync", version = "=0.5.0" }
+galeon-engine-three-sync = { path = "../engine-three-sync", version = "=0.5.1" }

--- a/crates/engine-three-sync/Cargo.toml
+++ b/crates/engine-three-sync/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-development", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-galeon-engine = { path = "../engine", version = "=0.5.0" }
+galeon-engine = { path = "../engine", version = "=0.5.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["galeon", "ecs", "game-engine", "entity"]
 categories = ["game-development"]
 
 [dependencies]
-galeon-engine-macros = { path = "../engine-macros", version = "=0.5.0" }
+galeon-engine-macros = { path = "../engine-macros", version = "=0.5.1" }
 inventory = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/instanced-cubes/package.json
+++ b/examples/instanced-cubes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/example-instanced-cubes",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "5000-cube benchmark exercising the GPU-instanced render path",
   "type": "module",
@@ -10,8 +10,8 @@
     "start": "bun build src/main.ts --outdir=dist --target=browser --format=esm --watch"
   },
   "dependencies": {
-    "@galeon/render-core": "=0.5.0",
-    "@galeon/three": "=0.5.0",
+    "@galeon/render-core": "=0.5.1",
+    "@galeon/three": "=0.5.1",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/picking/package.json
+++ b/packages/picking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/picking",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Mouse picking and drag-rectangle selection helper for Galeon scenes",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/three": "=0.5.0",
+    "@galeon/three": "=0.5.1",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/packages/r3f/package.json
+++ b/packages/r3f/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/r3f",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "React Three Fiber adapter for Galeon render snapshots",
   "type": "module",
   "main": "dist/index.js",
@@ -23,9 +23,9 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/picking": "=0.5.0",
-    "@galeon/render-core": "=0.5.0",
-    "@galeon/three": "=0.5.0"
+    "@galeon/picking": "=0.5.1",
+    "@galeon/render-core": "=0.5.1",
+    "@galeon/three": "=0.5.1"
   },
   "devDependencies": {
     "@react-three/fiber": "^9.6.1",

--- a/packages/render-core/package.json
+++ b/packages/render-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/render-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Framework-neutral Galeon render snapshot contract and packet guardrails",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/runtime",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Galeon Engine runtime — thin JS↔WASM invoke/events bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/shell",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Galeon Engine editor shell — Godot-style Solid.js panel UI",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galeon/three",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Imperative Three.js adapter for Galeon render snapshots",
   "type": "module",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
     "prepublishOnly": "tsc --build"
   },
   "dependencies": {
-    "@galeon/render-core": "=0.5.0",
+    "@galeon/render-core": "=0.5.1",
     "@three.ez/instanced-mesh": "0.3.15",
     "three": "^0.183.2"
   },


### PR DESCRIPTION
<!-- shiplog:
kind: history
status: open
phase: 5
issue: 248
readiness: done
updated_at: 2026-05-03T08:50:00Z
-->

## Summary

Closes #248. Bumps every lockstep-published artifact from `0.5.0` to `0.5.1` ahead of the `v0.5.1` tag cut. Patch release per `docs/guide/publishing.md` (pre-1.0 backward-compatible bug fix).

The only post-0.5.0 user-facing change is **#246 / #247** (CLI scaffold engine pin auto-tracking via `build.rs`). No public API changes. Scaffold output stays `galeon-engine = "0.5"` after this bump — patch releases don't move the major.minor pin, and downstream caret semantics on `"0.5"` already pick up `0.5.1` automatically.

### What's bumped (11 files, 19 locations — driven by `scripts/bump-version.sh 0.5.1`)

- Workspace: `Cargo.toml`
- Internal `=` pins: `crates/engine/Cargo.toml`, `crates/engine-terrain/Cargo.toml`, `crates/engine-three-sync/Cargo.toml`
- npm packages: `packages/{runtime,render-core,three,picking,r3f,shell}/package.json` (versions + cross-`@galeon/*` `=` pins where applicable)
- Example pin: `examples/instanced-cubes/package.json`
- `Cargo.lock` regenerated by `cargo build --workspace`
- `CHANGELOG.md`: `## [Unreleased]` content moved under `## [0.5.1] - 2026-05-03` (Keep a Changelog format)

`galeon-cli` inherits the workspace version automatically, so it does not need a separate version edit.

### Why this is the first cut after the new build-time guard

The build.rs cross-check from #247 enforces `engine package version == galeon-cli CARGO_PKG_VERSION` at every workspace build. If any `=0.5.0` → `=0.5.1` pin had been forgotten by the bump script, `cargo build` would have panicked with a clear pointer at the offending file/line. It stayed quiet — confirmation that lockstep is intact.

`cargo publish --dry-run -p galeon-cli` is also part of the verification gate now (regression #247 caught pre-merge). First time exercised against a real version bump; clean.

## Journey Timeline

| Phase | Artifact | Notes |
|-------|----------|-------|
| Plan Capture | [#248](https://github.com/galeon-engine/galeon/issues/248) | 4 tier-1 tasks: bump, CHANGELOG/lockfile refresh, full pre-release gate, this PR. |
| Branch Setup | [comment](https://github.com/galeon-engine/galeon/issues/248#issuecomment-4365727931) | Worktree off `origin/master` at `28084a7` (the merge tip of #247). |
| Bump | `6897237` | `bash scripts/bump-version.sh 0.5.1` → 19 locations updated; CHANGELOG headline moved; `Cargo.lock` regenerated. |

## Verification

- [x] `cargo build --workspace` — green; new `build.rs` cross-check stayed silent (lockstep enforced).
- [x] `cargo test --workspace` — 627 passed, 11 ignored.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo publish --dry-run -p galeon-cli` — succeeds end-to-end against `galeon-cli v0.5.1`.
- [x] Scaffold smoke (`local-first`): emits `galeon-engine = "0.5"` and `galeon-engine-three-sync = "0.5"` in `crates/{protocol,domain,client}/Cargo.toml`, `engine = "0.5"` in `galeon.toml` — unchanged from #246's verification (intentional; patch bumps don't move major.minor).

### Reproduce locally

```bash
git checkout issue/248-prepare-0-5-1-release
cargo build --workspace          # build.rs cross-check fires here if any =pin desynced
cargo test --workspace
cargo publish --dry-run -p galeon-cli
cargo run -p galeon-cli -- new tmp-smoke --preset local-first
grep galeon-engine tmp-smoke/crates/*/Cargo.toml
# galeon-engine = "0.5"  (and galeon-engine-three-sync = "0.5" in client)
rm -rf tmp-smoke
```

## Post-merge actions

After merging:

```bash
git fetch origin master
git tag v0.5.1 origin/master
git push origin v0.5.1
```

This fires `.github/workflows/release.yml`, which publishes:
- **crates.io:** `galeon-engine-macros`, `galeon-engine`, `galeon-engine-three-sync`, `galeon-engine-terrain`, `galeon-cli`
- **npm:** `@galeon/runtime`, `@galeon/render-core`, `@galeon/three`, `@galeon/picking`, `@galeon/r3f`, `@galeon/shell`

## Reviews

Current state: pending review
Last reviewed by: —
Last reviewed at: —
Reviewed commit: —
Source artifact: —
Needs re-review since: —

Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)

*Captain's log — PR timeline by **shiplog***
