### PR TITLE
feat(#252): add renderer host and frame ingestion primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Renderer runtime lifecycle primitives (#252 / T1-T2)** —
+- **Renderer runtime lifecycle primitives (issue #252, tasks T1-T2)** —
   `@galeon/three` now exports `RendererHost`, a backend-aware renderer/canvas
   lifecycle owner that keeps renderer identity stable across normal UI state
   changes. `@galeon/render-core` now exports `StateInterpolationBuffer` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Renderer runtime lifecycle primitives (#252 / T1-T2)** —
+  `@galeon/three` now exports `RendererHost`, a backend-aware renderer/canvas
+  lifecycle owner that keeps renderer identity stable across normal UI state
+  changes. `@galeon/render-core` now exports `StateInterpolationBuffer` and
+  `TransformFrameIngestion` so authoritative `FramePacket` transforms can be
+  buffered and sampled smoothly at render time.
+
 ## [0.5.1] - 2026-05-03
 
 ### Changed

--- a/docs/adr/0002-renderer-host-lifecycle.md
+++ b/docs/adr/0002-renderer-host-lifecycle.md
@@ -1,0 +1,52 @@
+# ADR-0002: Renderer Host Lifecycle Boundary
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Issue:** [#252](https://github.com/galeon-engine/galeon/issues/252)
+
+## Context
+
+Galeon consumers need to combine authoritative frame streams, Three.js
+renderers, UI shells, debug tools, and optional framework adapters. If a UI
+component owns the renderer directly, normal UI state changes can recreate the
+canvas, scene, animation loop, or renderer resources.
+
+That coupling makes rendering correctness depend on application glue instead
+of a reusable engine boundary.
+
+## Decision
+
+### Renderer host owns renderer and canvas lifecycle
+
+`RendererHost` owns the renderer adapter, canvas identity, frame loop,
+attachment, sizing, rendering, and disposal. UI shells can attach the canvas
+and subscribe to frame callbacks, but toggling unrelated UI should not recreate
+the host.
+
+### Backend adapter stays host-side
+
+The host depends on a small adapter interface instead of hard-coding a specific
+Three.js renderer class. WebGL and WebGPU renderer construction remains an
+adapter concern, coordinated with #153.
+
+### Frame ingestion remains separate from scene reconciliation
+
+`TransformFrameIngestion` buffers authoritative `FramePacket` transform state
+for render-time sampling. It does not own simulation ticking and does not
+replace `RendererCache`; it gives hosts and camera controllers a stable
+interpolation boundary between authority updates and render frames.
+
+### Errors must be surfaced
+
+Frame-loop callback and render errors are part of the host lifecycle contract.
+They must be reported through host error handling instead of silently freezing
+the canvas.
+
+## Consequences
+
+- Renderer identity can remain stable across UI state changes.
+- Games can keep Rust as the authority while smoothing render-time samples on
+  the host side.
+- Devtools and UI shells can attach to a host without owning its resources.
+- Resource catalogs, camera controllers, and runtime verification can build on
+  a stable lifecycle boundary in follow-up tasks.

--- a/docs/adr/0004-renderer-host-lifecycle.md
+++ b/docs/adr/0004-renderer-host-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0002: Renderer Host Lifecycle Boundary
+# ADR 0004: Renderer Host Lifecycle Boundary
 
 **Status:** Accepted
 **Date:** 2026-05-10

--- a/docs/guide/three-sync.md
+++ b/docs/guide/three-sync.md
@@ -120,7 +120,7 @@ sample those snapshots between authority updates.
 renderer/canvas owner outside UI component state. The host owns the renderer
 adapter, canvas attachment, animation loop, frame count, and disposal path;
 ordinary UI toggles and devtools panels should attach to the host instead of
-recreating the renderer or scene.
+recreating the renderer or scene. ADR 0004 records the lifecycle boundary.
 
 ### Borrow-Split Pattern
 
@@ -143,8 +143,12 @@ clones the backing `Vec`, which wasm-bindgen converts to a JS typed array
 When present with per-row data, each byte is a bitmask for incremental
 extraction (`extract_frame_incremental`). Empty arrays are valid in both
 full `extract_frame` and no-change incremental snapshots, so packet shape
-alone is not a reliable mode signal. `@galeon/three`'s `RendererCache` uses
-row flags to skip redundant Three.js writes when they are present.
+alone is not a reliable mode signal. `@galeon/three`'s `RendererCache`
+therefore treats `applyFrame(packet)` as a full snapshot by default. Consumers
+applying deltas must call `applyIncrementalFrame(packet)` or
+`applyFrame(packet, { mode: "incremental" })`; non-empty incremental packets
+must carry one `change_flags` row per entity so the cache can skip redundant
+Three.js writes without treating absence as despawn.
 
 **MVP transport:** copied flat buffers. Future optimisation: direct typed array
 views into WASM linear memory (zero-copy).
@@ -261,6 +265,10 @@ cache.registerMaterial(1, myStandardMaterial);
 // Per frame:
 const packet = engine.extract_frame();
 cache.applyFrame(packet);
+
+// Incremental deltas must opt into incremental cache semantics.
+const delta = engine.extract_frame_incremental();
+cache.applyIncrementalFrame(delta);
 ```
 
 **Per-frame behaviour (two-pass):**
@@ -268,9 +276,9 @@ cache.applyFrame(packet);
 **Pass 1 — Create/Update objects:**
 
 - New entity IDs → create the requested `THREE.Object3D` type, add to scene (full row applied).
-- Existing IDs → when row-level `change_flags` are available, update only
-  transform, visibility, and mesh/material resolution for bits set in the flag;
-  otherwise behave as a full update (same end state as before).
+- Existing IDs → full packets update all renderer-owned fields; explicit
+  incremental packets use row-level `change_flags` to update only transform,
+  visibility, and mesh/material resolution for bits set in the flag.
 - `ObjectType` changes recreate the managed Three.js object while preserving
   the entity slot and hierarchy attachment.
 - Missing IDs in **full** packets → remove from scene. Incremental packets only
@@ -311,7 +319,7 @@ home of each symbol:
 | `import type { RendererEntityHandle } from "@galeon/engine-ts"` | `import type { RendererEntityHandle } from "@galeon/three"` |
 | `import { CHANGED_TRANSFORM, CHANGED_VISIBILITY, CHANGED_MESH, CHANGED_MATERIAL, CHANGED_OBJECT_TYPE, CHANGED_PARENT } from "@galeon/engine-ts"` | same names from `@galeon/render-core` |
 | `import { ObjectType, SCENE_ROOT, TRANSFORM_STRIDE, RENDER_CONTRACT_VERSION } from "@galeon/engine-ts"` | same names from `@galeon/render-core` |
-| `import { FramePacketContractError, assertFramePacketContract, hasIncrementalChangeFlags } from "@galeon/engine-ts"` | same names from `@galeon/render-core` |
+| `import { FramePacketContractError, assertFramePacketContract, hasIncrementalChangeFlags } from "@galeon/engine-ts"` | same names from `@galeon/render-core`; prefer `hasPerRowChangeFlags` for new code |
 | `import type { FramePacketContractOptions, FramePacketView } from "@galeon/engine-ts"` | same names from `@galeon/render-core` |
 | `import { RUNTIME_VERSION, runtimeVersion } from "@galeon/engine-ts"` | `import { RUNTIME_VERSION } from "@galeon/runtime"` (the wrapper added no value) |
 

--- a/docs/guide/three-sync.md
+++ b/docs/guide/three-sync.md
@@ -96,6 +96,31 @@ Each frame:
 └─────────────────────────────────────┘
 ```
 
+### Render-Time Ingestion
+
+`FramePacket` remains the authoritative transport, but render hosts may run at
+a higher cadence than upstream simulation snapshots. `@galeon/render-core`
+exports two small primitives for that boundary:
+
+- `StateInterpolationBuffer<K, T>` buffers arbitrary keyed state and samples
+  between authoritative updates using a caller-provided interpolator.
+- `TransformFrameIngestion` ingests `FramePacket` transforms by stable
+  `(entityId, generation)` keys and returns render-time transform samples.
+
+These primitives are generic host-side tools. They do not own simulation, they
+do not assume a game-specific entity type, and they preserve the Rust-first
+contract: Rust emits authoritative snapshots; renderer adapters decide how to
+sample those snapshots between authority updates.
+
+### Renderer Host Lifecycle
+
+`@galeon/three` exports `RendererHost` and
+`createThreeRendererHostAdapter(...)` for applications that need a stable
+renderer/canvas owner outside UI component state. The host owns the renderer
+adapter, canvas attachment, animation loop, frame count, and disposal path;
+ordinary UI toggles and devtools panels should attach to the host instead of
+recreating the renderer or scene.
+
 ### Borrow-Split Pattern
 
 The extraction function uses a two-pass pattern to work within Rust's borrow

--- a/docs/guide/three-sync.md
+++ b/docs/guide/three-sync.md
@@ -56,7 +56,8 @@ mesh_handles:     [u32; N]
 material_handles: [u32; N]
 parent_ids:       [u32; N]        // parent entity index; u32::MAX = scene root
 object_types:     [u8;  N]        // 0=Mesh, 1=PointLight, 2=DirectionalLight, 3=LineSegments, 4=Group
-change_flags:     [u8;  N]        // empty for full extract; bitmasks for incremental
+change_flags:     [u8;  N] | []   // row bitmasks when present; empty is valid
+                                  // and does not identify packet mode
 ```
 
 **Transform stride is 10 floats:**
@@ -138,10 +139,12 @@ rules:
 clones the backing `Vec`, which wasm-bindgen converts to a JS typed array
 (`Float32Array`, `Uint32Array`, `Uint8Array`).
 
-`change_flags` is a parallel `Uint8Array` of per-entity bitmasks for incremental
-extraction (`extract_frame_incremental`); it is empty for full `extract_frame`
-packets. `@galeon/three`'s `RendererCache` uses these flags to skip redundant
-Three.js writes when present.
+`change_flags` is a `Uint8Array` getter on real `WasmFramePacket` values.
+When present with per-row data, each byte is a bitmask for incremental
+extraction (`extract_frame_incremental`). Empty arrays are valid in both
+full `extract_frame` and no-change incremental snapshots, so packet shape
+alone is not a reliable mode signal. `@galeon/three`'s `RendererCache` uses
+row flags to skip redundant Three.js writes when they are present.
 
 **MVP transport:** copied flat buffers. Future optimisation: direct typed array
 views into WASM linear memory (zero-copy).
@@ -265,14 +268,14 @@ cache.applyFrame(packet);
 **Pass 1 — Create/Update objects:**
 
 - New entity IDs → create the requested `THREE.Object3D` type, add to scene (full row applied).
-- Existing IDs → when `change_flags` is present, update only transform, visibility,
-  and mesh/material resolution for bits set in the flag; when absent or empty,
-  behave as a full update (same end state as before).
+- Existing IDs → when row-level `change_flags` are available, update only
+  transform, visibility, and mesh/material resolution for bits set in the flag;
+  otherwise behave as a full update (same end state as before).
 - `ObjectType` changes recreate the managed Three.js object while preserving
   the entity slot and hierarchy attachment.
-- Missing IDs in **full** packets (no `change_flags`) → remove from scene.
-  Incremental packets only include changed entities, so missing IDs do
-  **not** trigger removal — absence means unchanged, not despawned.
+- Missing IDs in **full** packets → remove from scene. Incremental packets only
+  include changed entities, so missing IDs do **not** trigger removal — absence
+  means unchanged, not despawned.
 - Unknown mesh/material handles → placeholder (magenta wireframe box).
 - **Custom channels** (`custom_channel_*`) → copied into `userData` for every entity
   in the packet on every frame. They are **not** gated by `change_flags` today

--- a/packages/r3f/src/entity-store.ts
+++ b/packages/r3f/src/entity-store.ts
@@ -4,7 +4,7 @@ import {
   ObjectType,
   SCENE_ROOT,
   TRANSFORM_STRIDE,
-  hasIncrementalChangeFlags,
+  hasPerRowChangeFlags,
   type FramePacketView,
 } from "@galeon/render-core";
 import type { RendererCache } from "@galeon/three";
@@ -31,7 +31,7 @@ export class GaleonEntityStore {
   private ordered: GaleonEntityRef[] = [];
 
   sync(packet: FramePacketView, cache: RendererCache): boolean {
-    if (hasIncrementalChangeFlags(packet)) {
+    if (hasPerRowChangeFlags(packet)) {
       const results = GaleonEntityStore.rowIndexes(packet).map((row) =>
         this.upsertEntity(packet, row, cache),
       );

--- a/packages/r3f/tests/entity-store.test.ts
+++ b/packages/r3f/tests/entity-store.test.ts
@@ -113,7 +113,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
     hotUpdate.transforms[0] = 77;
-    cache.applyFrame(hotUpdate);
+    cache.applyIncrementalFrame(hotUpdate);
     expect(store.sync(hotUpdate, cache)).toBe(false);
 
     const hotRef = store.get(1, 0)!;
@@ -144,7 +144,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
       frame_version: 2n,
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
-    cache.applyFrame(incrementalSpawn);
+    cache.applyIncrementalFrame(incrementalSpawn);
     expect(store.sync(incrementalSpawn, cache)).toBe(true);
 
     expect(store.entities()).not.toBe(entitiesBefore);
@@ -176,7 +176,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
       change_flags: new Uint8Array([CHANGED_OBJECT_TYPE]),
       frame_version: 2n,
     });
-    cache.applyFrame(lightFrame);
+    cache.applyIncrementalFrame(lightFrame);
     expect(store.sync(lightFrame, cache)).toBe(true);
 
     expect(store.entities()).not.toBe(entitiesBefore);

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -260,12 +260,16 @@ export class TransformFrameIngestion {
       readonly transform: TransformState;
     }> = [];
     const stagedTransformKeys = new Set<string>();
+    const removedKeys: string[] = [];
 
     for (let i = 0; i < packet.entity_count; i++) {
       const entityId = packet.entity_ids[i]!;
       const generation = packet.entity_generations[i]!;
       const key = frameEntityKey(entityId, generation);
       activeKeys.add(key);
+      removedKeys.push(
+        ...removeStaleEntityGenerations(nextEntities, entityId, generation),
+      );
 
       const tracked = nextEntities.get(key) ?? {
         entityId,
@@ -290,7 +294,6 @@ export class TransformFrameIngestion {
       }
     }
 
-    const removedKeys: string[] = [];
     if (!isIncremental) {
       for (const key of nextEntities.keys()) {
         if (activeKeys.has(key)) {
@@ -354,6 +357,21 @@ export class TransformFrameIngestion {
     this.entities.clear();
     this.transforms.clear();
   }
+}
+
+function removeStaleEntityGenerations(
+  entities: Map<string, TrackedEntity>,
+  entityId: number,
+  generation: number,
+): string[] {
+  const removedKeys: string[] = [];
+  for (const [key, entity] of entities) {
+    if (entity.entityId === entityId && entity.generation !== generation) {
+      entities.delete(key);
+      removedKeys.push(key);
+    }
+  }
+  return removedKeys;
 }
 
 export function transformStateFromPacket(

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -5,8 +5,6 @@ import {
   FramePacketContractError,
   TRANSFORM_STRIDE,
   assertFramePacketContract,
-  hasIncrementalChangeFlags,
-  isIncrementalFramePacket,
   type FramePacketView,
 } from "./index.js";
 
@@ -176,6 +174,12 @@ export interface TransformFrameIngestionOptions {
   readonly maxHistoryMs?: number;
 }
 
+export type TransformFrameIngestionMode = "full" | "incremental";
+
+export interface TransformFrameIngestOptions {
+  readonly mode?: TransformFrameIngestionMode;
+}
+
 interface TrackedEntity {
   readonly entityId: number;
   readonly generation: number;
@@ -222,11 +226,28 @@ export class TransformFrameIngestion {
     });
   }
 
-  ingestFrame(packet: FramePacketView, receivedAtMs = this.now()): void {
+  /**
+   * Ingest an authoritative frame snapshot. Full mode is the default.
+   * Use `mode: "incremental"` (or `ingestIncrementalFrame`) for delta packets.
+   */
+  ingestFrame(
+    packet: FramePacketView,
+    receivedAtMs = this.now(),
+    options: TransformFrameIngestOptions = {},
+  ): void {
+    const mode = options.mode ?? "full";
+    const isIncremental = mode === "incremental";
+    if (isIncremental && packet.entity_count > 0) {
+      const flagCount = packet.change_flags?.length ?? 0;
+      if (flagCount !== packet.entity_count) {
+        throw new FramePacketContractError(
+          `incremental ingestion requires change_flags length ${packet.entity_count}, got ${flagCount}`,
+        );
+      }
+    }
+
     assertFramePacketContract(packet);
 
-    const isIncremental = isIncrementalFramePacket(packet);
-    const hasRowFlags = hasIncrementalChangeFlags(packet);
     const flags = packet.change_flags;
     const activeKeys = new Set<string>();
     const nextEntities = new Map<string, TrackedEntity>();
@@ -254,10 +275,10 @@ export class TransformFrameIngestion {
       tracked.visible = packet.visibility[i]! === 1;
       nextEntities.set(key, tracked);
 
-      const rowFlags = flags?.[i] ?? 0;
+      const rowFlags = isIncremental ? flags![i]! : 0;
       const changedTransform =
         !isIncremental ||
-        (hasRowFlags && (rowFlags & CHANGED_TRANSFORM) !== 0) ||
+        (rowFlags & CHANGED_TRANSFORM) !== 0 ||
         stagedTransformKeys.has(key) ||
         !this.transforms.has(key);
       if (changedTransform) {
@@ -290,6 +311,14 @@ export class TransformFrameIngestion {
     for (const update of stagedTransforms) {
       this.transforms.push(update.key, receivedAtMs, update.transform);
     }
+  }
+
+  /** Convenience wrapper for ingesting incremental delta packets. */
+  ingestIncrementalFrame(
+    packet: FramePacketView,
+    receivedAtMs = this.now(),
+  ): void {
+    this.ingestFrame(packet, receivedAtMs, { mode: "incremental" });
   }
 
   sampleFrame(renderTimeMs = this.now() - this.interpolationDelayMs): TransformFrameSample[] {

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import {
+  CHANGED_TRANSFORM,
+  TRANSFORM_STRIDE,
+  assertFramePacketContract,
+  hasIncrementalChangeFlags,
+  type FramePacketView,
+} from "./index.js";
+
+export type StableRenderId = string | number;
+
+export interface TimedState<T> {
+  readonly timeMs: number;
+  readonly value: T;
+}
+
+export interface StateInterpolator<T> {
+  interpolate(from: T, to: T, alpha: number): T;
+}
+
+export interface StateInterpolationBufferOptions {
+  readonly maxHistoryMs?: number;
+}
+
+/**
+ * Generic render-time state buffer keyed by stable render ids.
+ *
+ * Authoritative updates can arrive at lower frequency than rendering; this
+ * buffer gives adapters a deterministic place to sample state between updates.
+ */
+export class StateInterpolationBuffer<K extends StableRenderId, T> {
+  private readonly states = new Map<K, TimedState<T>[]>();
+  private readonly maxHistoryMs: number;
+
+  constructor(
+    private readonly interpolator: StateInterpolator<T>,
+    options: StateInterpolationBufferOptions = {},
+  ) {
+    this.maxHistoryMs = options.maxHistoryMs ?? 1_000;
+  }
+
+  push(key: K, timeMs: number, value: T): void {
+    const history = this.states.get(key) ?? [];
+    history.push({ timeMs, value });
+    history.sort((a, b) => a.timeMs - b.timeMs);
+    this.pruneHistory(history, timeMs - this.maxHistoryMs);
+    this.states.set(key, history);
+  }
+
+  sample(key: K, timeMs: number): T | undefined {
+    const history = this.states.get(key);
+    if (history === undefined || history.length === 0) {
+      return undefined;
+    }
+
+    const first = history[0]!;
+    if (timeMs <= first.timeMs) {
+      return first.value;
+    }
+
+    const last = history[history.length - 1]!;
+    if (timeMs >= last.timeMs) {
+      return last.value;
+    }
+
+    for (let i = 1; i < history.length; i++) {
+      const next = history[i]!;
+      if (timeMs > next.timeMs) {
+        continue;
+      }
+      const prev = history[i - 1]!;
+      const span = next.timeMs - prev.timeMs;
+      const alpha = span <= 0 ? 1 : (timeMs - prev.timeMs) / span;
+      return this.interpolator.interpolate(prev.value, next.value, alpha);
+    }
+
+    return last.value;
+  }
+
+  snapshot(timeMs: number): Map<K, T> {
+    const result = new Map<K, T>();
+    for (const key of this.states.keys()) {
+      const value = this.sample(key, timeMs);
+      if (value !== undefined) {
+        result.set(key, value);
+      }
+    }
+    return result;
+  }
+
+  delete(key: K): void {
+    this.states.delete(key);
+  }
+
+  clear(): void {
+    this.states.clear();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.states.keys();
+  }
+
+  private pruneHistory(history: TimedState<T>[], minTimeMs: number): void {
+    while (history.length > 2 && history[1]!.timeMs < minTimeMs) {
+      history.shift();
+    }
+  }
+}
+
+export interface TransformState {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+  readonly qx: number;
+  readonly qy: number;
+  readonly qz: number;
+  readonly qw: number;
+  readonly sx: number;
+  readonly sy: number;
+  readonly sz: number;
+}
+
+export interface TransformFrameSample {
+  readonly key: string;
+  readonly entityId: number;
+  readonly generation: number;
+  readonly visible: boolean;
+  readonly transform: TransformState;
+}
+
+export interface TransformFrameIngestionOptions {
+  readonly now?: () => number;
+  readonly interpolationDelayMs?: number;
+  readonly maxHistoryMs?: number;
+}
+
+interface TrackedEntity {
+  readonly entityId: number;
+  readonly generation: number;
+  visible: boolean;
+}
+
+export function frameEntityKey(entityId: number, generation: number): string {
+  return `${entityId}:${generation}`;
+}
+
+export const transformInterpolator: StateInterpolator<TransformState> = {
+  interpolate(from, to, alpha) {
+    const t = clamp01(alpha);
+    const q = normalizeQuaternion(lerpQuaternion(from, to, t));
+    return {
+      x: lerp(from.x, to.x, t),
+      y: lerp(from.y, to.y, t),
+      z: lerp(from.z, to.z, t),
+      qx: q.qx,
+      qy: q.qy,
+      qz: q.qz,
+      qw: q.qw,
+      sx: lerp(from.sx, to.sx, t),
+      sy: lerp(from.sy, to.sy, t),
+      sz: lerp(from.sz, to.sz, t),
+    };
+  },
+};
+
+/**
+ * Ingests authoritative FramePacket transforms and exposes render-time samples.
+ */
+export class TransformFrameIngestion {
+  private readonly now: () => number;
+  private readonly interpolationDelayMs: number;
+  private readonly entities = new Map<string, TrackedEntity>();
+  private readonly transforms: StateInterpolationBuffer<string, TransformState>;
+
+  constructor(options: TransformFrameIngestionOptions = {}) {
+    this.now = options.now ?? (() => performance.now());
+    this.interpolationDelayMs = options.interpolationDelayMs ?? 100;
+    this.transforms = new StateInterpolationBuffer(transformInterpolator, {
+      maxHistoryMs: options.maxHistoryMs,
+    });
+  }
+
+  ingestFrame(packet: FramePacketView, receivedAtMs = this.now()): void {
+    assertFramePacketContract(packet);
+
+    const isIncremental = hasIncrementalChangeFlags(packet);
+    const activeKeys = new Set<string>();
+    for (let i = 0; i < packet.entity_count; i++) {
+      const entityId = packet.entity_ids[i]!;
+      const generation = packet.entity_generations[i]!;
+      const key = frameEntityKey(entityId, generation);
+      activeKeys.add(key);
+
+      const tracked = this.entities.get(key) ?? {
+        entityId,
+        generation,
+        visible: true,
+      };
+      tracked.visible = packet.visibility[i]! === 1;
+      this.entities.set(key, tracked);
+
+      const flags = packet.change_flags;
+      const changedTransform =
+        !isIncremental ||
+        flags === undefined ||
+        (flags[i]! & CHANGED_TRANSFORM) !== 0 ||
+        this.transforms.sample(key, receivedAtMs) === undefined;
+      if (changedTransform) {
+        this.transforms.push(
+          key,
+          receivedAtMs,
+          transformStateFromPacket(packet, i),
+        );
+      }
+    }
+
+    if (!isIncremental) {
+      for (const key of Array.from(this.entities.keys())) {
+        if (activeKeys.has(key)) {
+          continue;
+        }
+        this.entities.delete(key);
+        this.transforms.delete(key);
+      }
+    }
+  }
+
+  sampleFrame(renderTimeMs = this.now() - this.interpolationDelayMs): TransformFrameSample[] {
+    const samples: TransformFrameSample[] = [];
+    for (const [key, entity] of this.entities) {
+      const transform = this.transforms.sample(key, renderTimeMs);
+      if (transform === undefined) {
+        continue;
+      }
+      samples.push({
+        key,
+        entityId: entity.entityId,
+        generation: entity.generation,
+        visible: entity.visible,
+        transform,
+      });
+    }
+    return samples;
+  }
+
+  sampleEntity(
+    entityId: number,
+    generation: number,
+    renderTimeMs = this.now() - this.interpolationDelayMs,
+  ): TransformState | undefined {
+    return this.transforms.sample(
+      frameEntityKey(entityId, generation),
+      renderTimeMs,
+    );
+  }
+
+  clear(): void {
+    this.entities.clear();
+    this.transforms.clear();
+  }
+}
+
+export function transformStateFromPacket(
+  packet: FramePacketView,
+  index: number,
+): TransformState {
+  const offset = index * TRANSFORM_STRIDE;
+  return {
+    x: packet.transforms[offset]!,
+    y: packet.transforms[offset + 1]!,
+    z: packet.transforms[offset + 2]!,
+    qx: packet.transforms[offset + 3]!,
+    qy: packet.transforms[offset + 4]!,
+    qz: packet.transforms[offset + 5]!,
+    qw: packet.transforms[offset + 6]!,
+    sx: packet.transforms[offset + 7]!,
+    sy: packet.transforms[offset + 8]!,
+    sz: packet.transforms[offset + 9]!,
+  };
+}
+
+function lerp(from: number, to: number, alpha: number): number {
+  return from + (to - from) * alpha;
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function lerpQuaternion(
+  from: TransformState,
+  to: TransformState,
+  alpha: number,
+): Pick<TransformState, "qx" | "qy" | "qz" | "qw"> {
+  const dot =
+    from.qx * to.qx +
+    from.qy * to.qy +
+    from.qz * to.qz +
+    from.qw * to.qw;
+  const sign = dot < 0 ? -1 : 1;
+  return {
+    qx: lerp(from.qx, to.qx * sign, alpha),
+    qy: lerp(from.qy, to.qy * sign, alpha),
+    qz: lerp(from.qz, to.qz * sign, alpha),
+    qw: lerp(from.qw, to.qw * sign, alpha),
+  };
+}
+
+function normalizeQuaternion(
+  q: Pick<TransformState, "qx" | "qy" | "qz" | "qw">,
+): Pick<TransformState, "qx" | "qy" | "qz" | "qw"> {
+  const length = Math.hypot(q.qx, q.qy, q.qz, q.qw);
+  if (length === 0) {
+    return { qx: 0, qy: 0, qz: 0, qw: 1 };
+  }
+  return {
+    qx: q.qx / length,
+    qy: q.qy / length,
+    qz: q.qz / length,
+    qw: q.qw / length,
+  };
+}

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -2,13 +2,16 @@
 
 import {
   CHANGED_TRANSFORM,
+  FramePacketContractError,
   TRANSFORM_STRIDE,
   assertFramePacketContract,
   hasIncrementalChangeFlags,
+  isIncrementalFramePacket,
   type FramePacketView,
 } from "./index.js";
 
-export type StableRenderId = string | number;
+/** String key used to correlate render samples over time. */
+export type StableRenderId = string;
 
 export interface TimedState<T> {
   readonly timeMs: number;
@@ -42,10 +45,20 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
 
   push(key: K, timeMs: number, value: T): void {
     const history = this.states.get(key) ?? [];
-    history.push({ timeMs, value });
-    history.sort((a, b) => a.timeMs - b.timeMs);
-    this.pruneHistory(history, timeMs - this.maxHistoryMs);
+    const sample = { timeMs, value };
+    const last = history[history.length - 1];
+    if (last === undefined || timeMs >= last.timeMs) {
+      history.push(sample);
+    } else {
+      history.splice(this.findInsertionIndex(history, timeMs), 0, sample);
+    }
+    const latestTimeMs = history[history.length - 1]!.timeMs;
+    this.pruneHistory(history, latestTimeMs - this.maxHistoryMs);
     this.states.set(key, history);
+  }
+
+  has(key: K): boolean {
+    return this.states.has(key);
   }
 
   sample(key: K, timeMs: number): T | undefined {
@@ -101,9 +114,34 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
     return this.states.keys();
   }
 
+  private findInsertionIndex(history: TimedState<T>[], timeMs: number): number {
+    let low = 0;
+    let high = history.length;
+    while (low < high) {
+      const middle = (low + high) >> 1;
+      if (history[middle]!.timeMs <= timeMs) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  }
+
+  /**
+   * Keep at least two samples so interpolation remains stable while trimming
+   * entries older than the retention window.
+   */
   private pruneHistory(history: TimedState<T>[], minTimeMs: number): void {
-    while (history.length > 2 && history[1]!.timeMs < minTimeMs) {
-      history.shift();
+    let pruneCount = 0;
+    while (
+      history.length - pruneCount > 2 &&
+      history[pruneCount + 1]!.timeMs < minTimeMs
+    ) {
+      pruneCount++;
+    }
+    if (pruneCount > 0) {
+      history.splice(0, pruneCount);
     }
   }
 }
@@ -122,8 +160,11 @@ export interface TransformState {
 }
 
 export interface TransformFrameSample {
+  /** Canonical stable id, derived from `entityId:generation`. */
   readonly key: string;
+  /** Source entity id from the authoritative frame packet. */
   readonly entityId: number;
+  /** Generation paired with `entityId`; together they derive `key`. */
   readonly generation: number;
   readonly visible: boolean;
   readonly transform: TransformState;
@@ -184,45 +225,70 @@ export class TransformFrameIngestion {
   ingestFrame(packet: FramePacketView, receivedAtMs = this.now()): void {
     assertFramePacketContract(packet);
 
-    const isIncremental = hasIncrementalChangeFlags(packet);
+    const isIncremental = isIncrementalFramePacket(packet);
+    const hasRowFlags = hasIncrementalChangeFlags(packet);
+    const flags = packet.change_flags;
     const activeKeys = new Set<string>();
+    const nextEntities = new Map<string, TrackedEntity>();
+    for (const [key, entity] of this.entities) {
+      nextEntities.set(key, { ...entity });
+    }
+
+    const stagedTransforms: Array<{
+      readonly key: string;
+      readonly transform: TransformState;
+    }> = [];
+    const stagedTransformKeys = new Set<string>();
+
     for (let i = 0; i < packet.entity_count; i++) {
       const entityId = packet.entity_ids[i]!;
       const generation = packet.entity_generations[i]!;
       const key = frameEntityKey(entityId, generation);
       activeKeys.add(key);
 
-      const tracked = this.entities.get(key) ?? {
+      const tracked = nextEntities.get(key) ?? {
         entityId,
         generation,
         visible: true,
       };
       tracked.visible = packet.visibility[i]! === 1;
-      this.entities.set(key, tracked);
+      nextEntities.set(key, tracked);
 
-      const flags = packet.change_flags;
+      const rowFlags = flags?.[i] ?? 0;
       const changedTransform =
         !isIncremental ||
-        flags === undefined ||
-        (flags[i]! & CHANGED_TRANSFORM) !== 0 ||
-        this.transforms.sample(key, receivedAtMs) === undefined;
+        (hasRowFlags && (rowFlags & CHANGED_TRANSFORM) !== 0) ||
+        stagedTransformKeys.has(key) ||
+        !this.transforms.has(key);
       if (changedTransform) {
-        this.transforms.push(
+        stagedTransforms.push({
           key,
-          receivedAtMs,
-          transformStateFromPacket(packet, i),
-        );
+          transform: transformStateFromPacket(packet, i),
+        });
+        stagedTransformKeys.add(key);
       }
     }
 
+    const removedKeys: string[] = [];
     if (!isIncremental) {
-      for (const key of Array.from(this.entities.keys())) {
+      for (const key of nextEntities.keys()) {
         if (activeKeys.has(key)) {
           continue;
         }
-        this.entities.delete(key);
-        this.transforms.delete(key);
+        removedKeys.push(key);
+        nextEntities.delete(key);
       }
+    }
+
+    this.entities.clear();
+    for (const [key, entity] of nextEntities) {
+      this.entities.set(key, entity);
+    }
+    for (const key of removedKeys) {
+      this.transforms.delete(key);
+    }
+    for (const update of stagedTransforms) {
+      this.transforms.push(update.key, receivedAtMs, update.transform);
     }
   }
 
@@ -266,7 +332,7 @@ export function transformStateFromPacket(
   index: number,
 ): TransformState {
   const offset = index * TRANSFORM_STRIDE;
-  return {
+  const transform: TransformState = {
     x: packet.transforms[offset]!,
     y: packet.transforms[offset + 1]!,
     z: packet.transforms[offset + 2]!,
@@ -278,6 +344,8 @@ export function transformStateFromPacket(
     sy: packet.transforms[offset + 8]!,
     sz: packet.transforms[offset + 9]!,
   };
+  assertFiniteTransform(transform, index);
+  return transform;
 }
 
 function lerp(from: number, to: number, alpha: number): number {
@@ -298,6 +366,8 @@ function lerpQuaternion(
     from.qy * to.qy +
     from.qz * to.qz +
     from.qw * to.qw;
+  // Quaternion q and -q encode the same rotation. Flip sign on negative dot
+  // so interpolation follows the shortest arc and avoids visible inversion.
   const sign = dot < 0 ? -1 : 1;
   return {
     qx: lerp(from.qx, to.qx * sign, alpha),
@@ -305,6 +375,16 @@ function lerpQuaternion(
     qz: lerp(from.qz, to.qz * sign, alpha),
     qw: lerp(from.qw, to.qw * sign, alpha),
   };
+}
+
+function assertFiniteTransform(transform: TransformState, index: number): void {
+  for (const [field, value] of Object.entries(transform)) {
+    if (!Number.isFinite(value)) {
+      throw new FramePacketContractError(
+        `transforms[${index}] has non-finite ${field}: ${value}`,
+      );
+    }
+  }
 }
 
 function normalizeQuaternion(

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -21,6 +21,7 @@ export interface StateInterpolator<T> {
 }
 
 export interface StateInterpolationBufferOptions {
+  /** Retention window per key in milliseconds. Defaults to `1000`. */
   readonly maxHistoryMs?: number;
 }
 
@@ -41,6 +42,11 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
     this.maxHistoryMs = options.maxHistoryMs ?? 1_000;
   }
 
+  /**
+   * Record a new authoritative sample for a key at `timeMs`.
+   *
+   * Samples may arrive out of order; insertion stays time-sorted.
+   */
   push(key: K, timeMs: number, value: T): void {
     const history = this.states.get(key) ?? [];
     const sample = { timeMs, value };
@@ -55,10 +61,16 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
     this.states.set(key, history);
   }
 
+  /** True when a key currently has at least one stored sample. */
   has(key: K): boolean {
     return this.states.has(key);
   }
 
+  /**
+   * Sample interpolated state at `timeMs`.
+   *
+   * Returns the closest boundary sample when `timeMs` is outside known history.
+   */
   sample(key: K, timeMs: number): T | undefined {
     const history = this.states.get(key);
     if (history === undefined || history.length === 0) {
@@ -89,6 +101,7 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
     return last.value;
   }
 
+  /** Sample all tracked keys at `timeMs` into a new snapshot map. */
   snapshot(timeMs: number): Map<K, T> {
     const result = new Map<K, T>();
     for (const key of this.states.keys()) {
@@ -100,14 +113,17 @@ export class StateInterpolationBuffer<K extends StableRenderId, T> {
     return result;
   }
 
+  /** Remove all history for a single key. */
   delete(key: K): void {
     this.states.delete(key);
   }
 
+  /** Remove all tracked key histories. */
   clear(): void {
     this.states.clear();
   }
 
+  /** Iterate tracked keys that currently have history entries. */
   keys(): IterableIterator<K> {
     return this.states.keys();
   }
@@ -170,6 +186,7 @@ export interface TransformFrameSample {
 
 export interface TransformFrameIngestionOptions {
   readonly now?: () => number;
+  /** Interpolation offset for default sampling. Defaults to `100` milliseconds. */
   readonly interpolationDelayMs?: number;
   readonly maxHistoryMs?: number;
 }
@@ -209,9 +226,7 @@ export const transformInterpolator: StateInterpolator<TransformState> = {
   },
 };
 
-/**
- * Ingests authoritative FramePacket transforms and exposes render-time samples.
- */
+/** Ingests authoritative frame packets and serves render-time transform samples. */
 export class TransformFrameIngestion {
   private readonly now: () => number;
   private readonly interpolationDelayMs: number;
@@ -324,7 +339,14 @@ export class TransformFrameIngestion {
     this.ingestFrame(packet, receivedAtMs, { mode: "incremental" });
   }
 
-  sampleFrame(renderTimeMs = this.now() - this.interpolationDelayMs): TransformFrameSample[] {
+  /**
+   * Sample all tracked entities at `renderTimeMs`.
+   *
+   * Defaults to `now() - interpolationDelayMs` (100ms unless configured).
+   */
+  sampleFrame(
+    renderTimeMs = this.now() - this.interpolationDelayMs,
+  ): TransformFrameSample[] {
     const samples: TransformFrameSample[] = [];
     for (const [key, entity] of this.entities) {
       const transform = this.transforms.sample(key, renderTimeMs);
@@ -342,6 +364,11 @@ export class TransformFrameIngestion {
     return samples;
   }
 
+  /**
+   * Sample one entity generation at `renderTimeMs`.
+   *
+   * Defaults to `now() - interpolationDelayMs` (100ms unless configured).
+   */
   sampleEntity(
     entityId: number,
     generation: number,
@@ -353,6 +380,7 @@ export class TransformFrameIngestion {
     );
   }
 
+  /** Clear tracked entities and interpolation history. */
   clear(): void {
     this.entities.clear();
     this.transforms.clear();

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -62,7 +62,12 @@ export interface FramePacketView {
   readonly material_handles: Uint32Array;
   /** Parent entity indices. `SCENE_ROOT` (0xFFFFFFFF) = child of scene root. */
   readonly parent_ids: Uint32Array;
-  /** Set for incremental extraction; omit or empty for full frames (all fields apply). */
+  /**
+   * Set by incremental extraction. May be empty when an incremental tick has
+   * no changed entities.
+   *
+   * Full-frame extraction omits this field.
+   */
   readonly change_flags?: Uint8Array;
   /** Object type per entity (0=Mesh, 1=PointLight, 2=DirectionalLight, 3=LineSegments, 4=Group). */
   readonly object_types?: Uint8Array;
@@ -157,7 +162,12 @@ function assertLength(
 const EMPTY_U32 = new Uint32Array(0);
 const EMPTY_F32 = new Float32Array(0);
 
-/** True when this packet is incremental and carries per-row change flags. */
+/** True when this packet came from incremental extraction (including empty packets). */
+export function isIncrementalFramePacket(packet: FramePacketView): boolean {
+  return packet.change_flags !== undefined;
+}
+
+/** True when an incremental packet also carries per-row change flags. */
 export function hasIncrementalChangeFlags(packet: FramePacketView): boolean {
   return packet.change_flags !== undefined && packet.change_flags.length > 0;
 }
@@ -223,8 +233,16 @@ export function assertFramePacketContract(
     assertLength("tints", packet.tints.length, entityCount * 3);
   }
 
-  if (packet.change_flags !== undefined && packet.change_flags.length > 0) {
-    assertLength("change_flags", packet.change_flags.length, entityCount);
+  if (packet.change_flags !== undefined) {
+    if (packet.change_flags.length === 0) {
+      if (entityCount > 0) {
+        throw new FramePacketContractError(
+          "change_flags must have one flag per entity when entity_count > 0",
+        );
+      }
+    } else {
+      assertLength("change_flags", packet.change_flags.length, entityCount);
+    }
   }
 
   const eventCount = packet.event_count ?? 0;

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -165,9 +165,15 @@ const EMPTY_U32 = new Uint32Array(0);
 const EMPTY_F32 = new Float32Array(0);
 
 /** True when a packet carries non-empty per-row change flags. */
-export function hasIncrementalChangeFlags(packet: FramePacketView): boolean {
+export function hasPerRowChangeFlags(packet: FramePacketView): boolean {
   return packet.change_flags !== undefined && packet.change_flags.length > 0;
 }
+
+/**
+ * @deprecated Use `hasPerRowChangeFlags`. Non-empty row flags imply row-level
+ * change data, but empty flags do not identify full vs incremental mode.
+ */
+export const hasIncrementalChangeFlags = hasPerRowChangeFlags;
 
 /**
  * Validate render packet structural invariants and contract compatibility.

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -277,3 +277,18 @@ export function assertFramePacketContract(
     }
   }
 }
+
+export {
+  StateInterpolationBuffer,
+  TransformFrameIngestion,
+  frameEntityKey,
+  transformInterpolator,
+  transformStateFromPacket,
+  type StableRenderId,
+  type StateInterpolationBufferOptions,
+  type StateInterpolator,
+  type TimedState,
+  type TransformFrameIngestionOptions,
+  type TransformFrameSample,
+  type TransformState,
+} from "./frame-ingestion.js";

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -63,10 +63,12 @@ export interface FramePacketView {
   /** Parent entity indices. `SCENE_ROOT` (0xFFFFFFFF) = child of scene root. */
   readonly parent_ids: Uint32Array;
   /**
-   * Set by incremental extraction. May be empty when an incremental tick has
-   * no changed entities.
+   * Per-row change bitmasks when present.
    *
-   * Full-frame extraction omits this field.
+   * Optional for non-WASM/test/legacy packet shapes. Real `WasmFramePacket`
+   * getters currently always expose a `Uint8Array`. An empty array does not
+   * identify packet mode by itself: full `extract_frame` and no-change
+   * incremental snapshots can both expose empty flags.
    */
   readonly change_flags?: Uint8Array;
   /** Object type per entity (0=Mesh, 1=PointLight, 2=DirectionalLight, 3=LineSegments, 4=Group). */
@@ -162,12 +164,7 @@ function assertLength(
 const EMPTY_U32 = new Uint32Array(0);
 const EMPTY_F32 = new Float32Array(0);
 
-/** True when this packet came from incremental extraction (including empty packets). */
-export function isIncrementalFramePacket(packet: FramePacketView): boolean {
-  return packet.change_flags !== undefined;
-}
-
-/** True when an incremental packet also carries per-row change flags. */
+/** True when a packet carries non-empty per-row change flags. */
 export function hasIncrementalChangeFlags(packet: FramePacketView): boolean {
   return packet.change_flags !== undefined && packet.change_flags.length > 0;
 }
@@ -233,16 +230,8 @@ export function assertFramePacketContract(
     assertLength("tints", packet.tints.length, entityCount * 3);
   }
 
-  if (packet.change_flags !== undefined) {
-    if (packet.change_flags.length === 0) {
-      if (entityCount > 0) {
-        throw new FramePacketContractError(
-          "change_flags must have one flag per entity when entity_count > 0",
-        );
-      }
-    } else {
-      assertLength("change_flags", packet.change_flags.length, entityCount);
-    }
+  if (packet.change_flags !== undefined && packet.change_flags.length > 0) {
+    assertLength("change_flags", packet.change_flags.length, entityCount);
   }
 
   const eventCount = packet.event_count ?? 0;
@@ -307,6 +296,8 @@ export {
   type StateInterpolator,
   type TimedState,
   type TransformFrameIngestionOptions,
+  type TransformFrameIngestOptions,
+  type TransformFrameIngestionMode,
   type TransformFrameSample,
   type TransformState,
 } from "./frame-ingestion.js";

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, test } from "bun:test";
 import {
   CHANGED_MATERIAL,
   CHANGED_TRANSFORM,
+  CHANGED_VISIBILITY,
   RENDER_CONTRACT_VERSION,
   SCENE_ROOT,
+  StateInterpolationBuffer,
   TRANSFORM_STRIDE,
   TransformFrameIngestion,
   frameEntityKey,
@@ -55,6 +57,43 @@ function setTransform(packet: FramePacketView, index: number, x: number): void {
 }
 
 describe("TransformFrameIngestion", () => {
+  test("StateInterpolationBuffer keeps history bounded while preserving two samples", () => {
+    const buffer = new StateInterpolationBuffer<string, number>(
+      {
+        interpolate(from, to, alpha) {
+          return from + (to - from) * alpha;
+        },
+      },
+      { maxHistoryMs: 50 },
+    );
+
+    buffer.push("unit", 0, 0);
+    buffer.push("unit", 100, 100);
+    buffer.push("unit", 200, 200);
+
+    expect(buffer.sample("unit", 0)).toBe(100);
+    expect(buffer.sample("unit", 150)).toBe(150);
+    expect(buffer.sample("unit", 200)).toBe(200);
+  });
+
+  test("StateInterpolationBuffer inserts out-of-order samples correctly", () => {
+    const buffer = new StateInterpolationBuffer<string, number>(
+      {
+        interpolate(from, to, alpha) {
+          return from + (to - from) * alpha;
+        },
+      },
+      { maxHistoryMs: 1_000 },
+    );
+
+    buffer.push("unit", 100, 100);
+    buffer.push("unit", 0, 0);
+    buffer.push("unit", 50, 50);
+
+    expect(buffer.sample("unit", 25)).toBe(25);
+    expect(buffer.sample("unit", 75)).toBe(75);
+  });
+
   test("samples transforms between authoritative frames", () => {
     const ingestion = new TransformFrameIngestion({
       now: () => 0,
@@ -122,6 +161,44 @@ describe("TransformFrameIngestion", () => {
     expect(ingestion.sampleEntity(1, 0, 32)).toBeUndefined();
   });
 
+  test("empty incremental packets do not evict tracked entities", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const full = makePacket({ entity_count: 1 });
+    full.entity_ids[0] = 3;
+    setTransform(full, 0, 9);
+    ingestion.ingestFrame(full, 0);
+
+    const emptyIncremental = makePacket({
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+    });
+    ingestion.ingestFrame(emptyIncremental, 16);
+
+    expect(ingestion.sampleEntity(3, 0, 16)?.x).toBe(9);
+  });
+
+  test("packets with entities require per-row change flags when marked incremental", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const malformed = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array(0),
+    });
+    malformed.entity_ids[0] = 8;
+    setTransform(malformed, 0, 1);
+
+    expect(() => ingestion.ingestFrame(malformed, 0)).toThrow(
+      /change_flags/i,
+    );
+  });
+
   test("incremental transform changes add new samples", () => {
     const ingestion = new TransformFrameIngestion({
       now: () => 0,
@@ -141,5 +218,125 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(incremental, 100);
 
     expect(ingestion.sampleEntity(9, 0, 25)?.x).toBe(5);
+  });
+
+  test("visibility toggles are reflected in sampled frames", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const full = makePacket({ entity_count: 1 });
+    full.entity_ids[0] = 4;
+    setTransform(full, 0, 1);
+    ingestion.ingestFrame(full, 0);
+
+    const incremental = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array([CHANGED_VISIBILITY]),
+    });
+    incremental.entity_ids[0] = 4;
+    incremental.visibility[0] = 0;
+    setTransform(incremental, 0, 1);
+    ingestion.ingestFrame(incremental, 50);
+
+    expect(ingestion.sampleFrame(50)[0]?.visible).toBe(false);
+  });
+
+  test("generation rollover evicts old generation keys on full frames", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 11;
+    first.entity_generations[0] = 1;
+    setTransform(first, 0, 2);
+    ingestion.ingestFrame(first, 0);
+
+    const rollover = makePacket({ entity_count: 1 });
+    rollover.entity_ids[0] = 11;
+    rollover.entity_generations[0] = 2;
+    setTransform(rollover, 0, 6);
+    ingestion.ingestFrame(rollover, 16);
+
+    expect(ingestion.sampleEntity(11, 1, 16)).toBeUndefined();
+    expect(ingestion.sampleEntity(11, 2, 16)?.x).toBe(6);
+  });
+
+  test("default interpolation delay samples now-100ms", () => {
+    let nowMs = 0;
+    const ingestion = new TransformFrameIngestion({
+      now: () => nowMs,
+    });
+
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 13;
+    setTransform(first, 0, 0);
+    ingestion.ingestFrame(first, 0);
+
+    const second = makePacket({ entity_count: 1 });
+    second.entity_ids[0] = 13;
+    setTransform(second, 0, 200);
+    ingestion.ingestFrame(second, 200);
+
+    nowMs = 250;
+    expect(ingestion.sampleFrame()[0]?.transform.x).toBe(150);
+  });
+
+  test("quaternion interpolation flips sign to keep shortest path", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 20;
+    setTransform(first, 0, 0);
+    ingestion.ingestFrame(first, 0);
+
+    const second = makePacket({ entity_count: 1 });
+    second.entity_ids[0] = 20;
+    setTransform(second, 0, 0);
+    second.transforms[6] = -1;
+    ingestion.ingestFrame(second, 100);
+
+    expect(ingestion.sampleEntity(20, 0, 50)?.qw).toBe(1);
+  });
+
+  test("malformed transforms throw and do not partially mutate state", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const baseline = makePacket({ entity_count: 1 });
+    baseline.entity_ids[0] = 30;
+    baseline.visibility[0] = 1;
+    setTransform(baseline, 0, 10);
+    ingestion.ingestFrame(baseline, 0);
+
+    const invalid = makePacket({
+      entity_count: 2,
+      change_flags: new Uint8Array([CHANGED_TRANSFORM, CHANGED_TRANSFORM]),
+    });
+    invalid.entity_ids[0] = 30;
+    invalid.visibility[0] = 0;
+    setTransform(invalid, 0, 20);
+    invalid.entity_ids[1] = 31;
+    setTransform(invalid, 1, 99);
+    invalid.transforms[TRANSFORM_STRIDE] = Number.NaN;
+
+    expect(() => ingestion.ingestFrame(invalid, 16)).toThrow(
+      /non-finite x/i,
+    );
+
+    expect(ingestion.sampleEntity(30, 0, 16)?.x).toBe(10);
+    expect(ingestion.sampleEntity(31, 0, 16)).toBeUndefined();
+    expect(
+      ingestion.sampleFrame(16).find((sample) => sample.key === frameEntityKey(30, 0))
+        ?.visible,
+    ).toBe(true);
   });
 });

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -95,6 +95,37 @@ describe("TransformFrameIngestion", () => {
     expect(buffer.sample("unit", 75)).toBe(75);
   });
 
+  test("StateInterpolationBuffer supports has/snapshot/delete/clear/keys", () => {
+    const buffer = new StateInterpolationBuffer<string, number>(
+      {
+        interpolate(from, to, alpha) {
+          return from + (to - from) * alpha;
+        },
+      },
+      { maxHistoryMs: 1_000 },
+    );
+
+    buffer.push("a", 0, 0);
+    buffer.push("a", 100, 100);
+    buffer.push("b", 100, 200);
+
+    expect(buffer.has("a")).toBe(true);
+    expect(buffer.has("missing")).toBe(false);
+    expect(Array.from(buffer.keys())).toEqual(["a", "b"]);
+
+    const snapshot = buffer.snapshot(50);
+    expect(snapshot.get("a")).toBe(50);
+    expect(snapshot.get("b")).toBe(200);
+
+    buffer.delete("a");
+    expect(buffer.has("a")).toBe(false);
+    expect(Array.from(buffer.keys())).toEqual(["b"]);
+
+    buffer.clear();
+    expect(Array.from(buffer.keys())).toEqual([]);
+    expect(buffer.snapshot(100).size).toBe(0);
+  });
+
   test("samples transforms between authoritative frames", () => {
     const ingestion = new TransformFrameIngestion({
       now: () => 0,
@@ -395,5 +426,26 @@ describe("TransformFrameIngestion", () => {
       ingestion.sampleFrame(16).find((sample) => sample.key === frameEntityKey(30, 0))
         ?.visible,
     ).toBe(true);
+  });
+
+  test("clear removes tracked entities and interpolation history", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const full = makePacket({ entity_count: 1 });
+    full.entity_ids[0] = 99;
+    full.entity_generations[0] = 3;
+    setTransform(full, 0, 42);
+    ingestion.ingestFrame(full, 0);
+
+    expect(ingestion.sampleEntity(99, 3, 0)?.x).toBe(42);
+    expect(ingestion.sampleFrame(0)).toHaveLength(1);
+
+    ingestion.clear();
+
+    expect(ingestion.sampleEntity(99, 3, 0)).toBeUndefined();
+    expect(ingestion.sampleFrame(0)).toEqual([]);
   });
 });

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import { describe, expect, test } from "bun:test";
+import {
+  CHANGED_MATERIAL,
+  CHANGED_TRANSFORM,
+  RENDER_CONTRACT_VERSION,
+  SCENE_ROOT,
+  TRANSFORM_STRIDE,
+  TransformFrameIngestion,
+  frameEntityKey,
+  type FramePacketView,
+} from "../src/index.js";
+
+function makePacket(
+  overrides: Partial<FramePacketView> & { entity_count: number },
+): FramePacketView {
+  const count = overrides.entity_count;
+  return {
+    contract_version: RENDER_CONTRACT_VERSION,
+    entity_count: count,
+    entity_ids: new Uint32Array(count),
+    entity_generations: new Uint32Array(count),
+    transforms: new Float32Array(count * TRANSFORM_STRIDE),
+    visibility: new Uint8Array(count).fill(1),
+    mesh_handles: new Uint32Array(count),
+    material_handles: new Uint32Array(count),
+    parent_ids: new Uint32Array(count).fill(SCENE_ROOT),
+    custom_channel_count: 0,
+    custom_channel_name_at: () => "",
+    custom_channel_stride: () => 1,
+    custom_channel_data: () => new Float32Array(0),
+    event_count: 0,
+    event_kinds: new Uint32Array(0),
+    event_entities: new Uint32Array(0),
+    event_positions: new Float32Array(0),
+    event_intensities: new Float32Array(0),
+    event_data: new Float32Array(0),
+    ...overrides,
+  };
+}
+
+function setTransform(packet: FramePacketView, index: number, x: number): void {
+  const offset = index * TRANSFORM_STRIDE;
+  packet.transforms[offset] = x;
+  packet.transforms[offset + 1] = 0;
+  packet.transforms[offset + 2] = 0;
+  packet.transforms[offset + 3] = 0;
+  packet.transforms[offset + 4] = 0;
+  packet.transforms[offset + 5] = 0;
+  packet.transforms[offset + 6] = 1;
+  packet.transforms[offset + 7] = 1;
+  packet.transforms[offset + 8] = 1;
+  packet.transforms[offset + 9] = 1;
+}
+
+describe("TransformFrameIngestion", () => {
+  test("samples transforms between authoritative frames", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 7;
+    first.entity_generations[0] = 2;
+    setTransform(first, 0, 0);
+
+    const second = makePacket({ entity_count: 1 });
+    second.entity_ids[0] = 7;
+    second.entity_generations[0] = 2;
+    setTransform(second, 0, 10);
+
+    ingestion.ingestFrame(first, 0);
+    ingestion.ingestFrame(second, 100);
+
+    expect(ingestion.sampleEntity(7, 2, 50)?.x).toBe(5);
+    expect(ingestion.sampleFrame(50)).toEqual([
+      {
+        key: frameEntityKey(7, 2),
+        entityId: 7,
+        generation: 2,
+        visible: true,
+        transform: {
+          x: 5,
+          y: 0,
+          z: 0,
+          qx: 0,
+          qy: 0,
+          qz: 0,
+          qw: 1,
+          sx: 1,
+          sy: 1,
+          sz: 1,
+        },
+      },
+    ]);
+  });
+
+  test("full frames evict missing entities but incremental frames do not", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+    const full = makePacket({ entity_count: 1 });
+    full.entity_ids[0] = 1;
+    setTransform(full, 0, 3);
+    ingestion.ingestFrame(full, 0);
+
+    const incremental = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array([CHANGED_MATERIAL]),
+    });
+    incremental.entity_ids[0] = 2;
+    setTransform(incremental, 0, 4);
+    ingestion.ingestFrame(incremental, 16);
+
+    expect(ingestion.sampleEntity(1, 0, 16)?.x).toBe(3);
+
+    const emptyFull = makePacket({ entity_count: 0 });
+    ingestion.ingestFrame(emptyFull, 32);
+
+    expect(ingestion.sampleEntity(1, 0, 32)).toBeUndefined();
+  });
+
+  test("incremental transform changes add new samples", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 9;
+    setTransform(first, 0, 0);
+    ingestion.ingestFrame(first, 0);
+
+    const incremental = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array([CHANGED_TRANSFORM]),
+    });
+    incremental.entity_ids[0] = 9;
+    setTransform(incremental, 0, 20);
+    ingestion.ingestFrame(incremental, 100);
+
+    expect(ingestion.sampleEntity(9, 0, 25)?.x).toBe(5);
+  });
+});

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -10,6 +10,7 @@ import {
   StateInterpolationBuffer,
   TRANSFORM_STRIDE,
   TransformFrameIngestion,
+  assertFramePacketContract,
   frameEntityKey,
   type FramePacketView,
 } from "../src/index.js";
@@ -151,7 +152,7 @@ describe("TransformFrameIngestion", () => {
     });
     incremental.entity_ids[0] = 2;
     setTransform(incremental, 0, 4);
-    ingestion.ingestFrame(incremental, 16);
+    ingestion.ingestIncrementalFrame(incremental, 16);
 
     expect(ingestion.sampleEntity(1, 0, 16)?.x).toBe(3);
 
@@ -176,12 +177,37 @@ describe("TransformFrameIngestion", () => {
       entity_count: 0,
       change_flags: new Uint8Array(0),
     });
-    ingestion.ingestFrame(emptyIncremental, 16);
+    ingestion.ingestIncrementalFrame(emptyIncremental, 16);
 
     expect(ingestion.sampleEntity(3, 0, 16)?.x).toBe(9);
   });
 
-  test("packets with entities require per-row change flags when marked incremental", () => {
+  test("full mode accepts empty change_flags with entities and evicts stale rows", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const baseline = makePacket({ entity_count: 2 });
+    baseline.entity_ids[0] = 41;
+    baseline.entity_ids[1] = 42;
+    setTransform(baseline, 0, 1);
+    setTransform(baseline, 1, 2);
+    ingestion.ingestFrame(baseline, 0);
+
+    const fullWithEmptyFlags = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array(0),
+    });
+    fullWithEmptyFlags.entity_ids[0] = 42;
+    setTransform(fullWithEmptyFlags, 0, 20);
+    ingestion.ingestFrame(fullWithEmptyFlags, 16);
+
+    expect(ingestion.sampleEntity(41, 0, 16)).toBeUndefined();
+    expect(ingestion.sampleEntity(42, 0, 16)?.x).toBe(20);
+  });
+
+  test("incremental mode with entities requires per-row change flags", () => {
     const ingestion = new TransformFrameIngestion({
       now: () => 0,
       interpolationDelayMs: 0,
@@ -194,7 +220,10 @@ describe("TransformFrameIngestion", () => {
     malformed.entity_ids[0] = 8;
     setTransform(malformed, 0, 1);
 
-    expect(() => ingestion.ingestFrame(malformed, 0)).toThrow(
+    expect(() => assertFramePacketContract(malformed)).not.toThrow();
+    expect(
+      () => ingestion.ingestFrame(malformed, 0, { mode: "incremental" }),
+    ).toThrow(
       /change_flags/i,
     );
   });
@@ -215,7 +244,7 @@ describe("TransformFrameIngestion", () => {
     });
     incremental.entity_ids[0] = 9;
     setTransform(incremental, 0, 20);
-    ingestion.ingestFrame(incremental, 100);
+    ingestion.ingestIncrementalFrame(incremental, 100);
 
     expect(ingestion.sampleEntity(9, 0, 25)?.x).toBe(5);
   });
@@ -238,7 +267,7 @@ describe("TransformFrameIngestion", () => {
     incremental.entity_ids[0] = 4;
     incremental.visibility[0] = 0;
     setTransform(incremental, 0, 1);
-    ingestion.ingestFrame(incremental, 50);
+    ingestion.ingestIncrementalFrame(incremental, 50);
 
     expect(ingestion.sampleFrame(50)[0]?.visible).toBe(false);
   });

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -294,6 +294,34 @@ describe("TransformFrameIngestion", () => {
     expect(ingestion.sampleEntity(11, 2, 16)?.x).toBe(6);
   });
 
+  test("generation rollover evicts old generation keys on incremental frames", () => {
+    const ingestion = new TransformFrameIngestion({
+      now: () => 0,
+      interpolationDelayMs: 0,
+    });
+
+    const first = makePacket({ entity_count: 1 });
+    first.entity_ids[0] = 12;
+    first.entity_generations[0] = 1;
+    setTransform(first, 0, 2);
+    ingestion.ingestFrame(first, 0);
+
+    const rollover = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array([CHANGED_TRANSFORM]),
+    });
+    rollover.entity_ids[0] = 12;
+    rollover.entity_generations[0] = 2;
+    setTransform(rollover, 0, 6);
+    ingestion.ingestIncrementalFrame(rollover, 16);
+
+    expect(ingestion.sampleEntity(12, 1, 16)).toBeUndefined();
+    expect(ingestion.sampleEntity(12, 2, 16)?.x).toBe(6);
+    expect(ingestion.sampleFrame(16).map((sample) => sample.key)).toEqual([
+      frameEntityKey(12, 2),
+    ]);
+  });
+
   test("default interpolation delay samples now-100ms", () => {
     let nowMs = 0;
     const ingestion = new TransformFrameIngestion({

--- a/packages/three/src/index.ts
+++ b/packages/three/src/index.ts
@@ -13,8 +13,12 @@ export {
   type RendererHostAdapter,
   type RendererHostBackend,
   type RendererHostClock,
+  type RendererHostErrorContext,
+  type RendererHostErrorHandler,
+  type RendererHostErrorPhase,
   type RendererHostFrame,
   type RendererHostOptions,
+  type RendererHostRenderer,
 } from "./renderer-host.js";
 
 export {

--- a/packages/three/src/index.ts
+++ b/packages/three/src/index.ts
@@ -3,6 +3,8 @@
 export {
   GALEON_ENTITY_KEY,
   RendererCache,
+  type RendererCacheApplyOptions,
+  type RendererCacheFrameMode,
   type RendererCacheOptions,
   type RendererEntityHandle,
 } from "./renderer-cache.js";
@@ -53,6 +55,7 @@ export {
   TRANSFORM_STRIDE,
   assertFramePacketContract,
   hasIncrementalChangeFlags,
+  hasPerRowChangeFlags,
   type FramePacketContractOptions,
   type FramePacketView,
 } from "@galeon/render-core";

--- a/packages/three/src/index.ts
+++ b/packages/three/src/index.ts
@@ -8,6 +8,16 @@ export {
 } from "./renderer-cache.js";
 
 export {
+  RendererHost,
+  createThreeRendererHostAdapter,
+  type RendererHostAdapter,
+  type RendererHostBackend,
+  type RendererHostClock,
+  type RendererHostFrame,
+  type RendererHostOptions,
+} from "./renderer-host.js";
+
+export {
   GALEON_INSTANCE_ENTITIES_KEY,
   InstancedMeshManager,
   type GaleonInstancedMesh,

--- a/packages/three/src/renderer-cache.ts
+++ b/packages/three/src/renderer-cache.ts
@@ -7,6 +7,7 @@ import {
   CHANGED_PARENT,
   CHANGED_TRANSFORM,
   CHANGED_VISIBILITY,
+  FramePacketContractError,
   INSTANCE_GROUP_NONE,
   assertFramePacketContract,
   type FramePacketView,
@@ -50,6 +51,12 @@ export interface RendererEntityHandle {
 
 export interface RendererCacheOptions {
   readonly instancing?: InstancedMeshManagerOptions;
+}
+
+export type RendererCacheFrameMode = "full" | "incremental";
+
+export interface RendererCacheApplyOptions {
+  readonly mode?: RendererCacheFrameMode;
 }
 
 export class RendererCache {
@@ -141,10 +148,26 @@ export class RendererCache {
   /**
    * Apply a frame packet to the scene graph.
    *
-   * Call once per render frame after `WasmEngine.extract_frame()`.
+   * Full mode is the default: every row represents the authoritative scene for
+   * that frame, and absent entities are removed. Use incremental mode only for
+   * explicit delta packets with one change flag per emitted entity.
    */
-  applyFrame(packet: FramePacketView): void {
+  applyFrame(
+    packet: FramePacketView,
+    options: RendererCacheApplyOptions = {},
+  ): void {
     assertFramePacketContract(packet);
+
+    const mode = options.mode ?? "full";
+    const isIncremental = mode === "incremental";
+    if (isIncremental && packet.entity_count > 0) {
+      const flagCount = packet.change_flags?.length ?? 0;
+      if (flagCount !== packet.entity_count) {
+        throw new FramePacketContractError(
+          `incremental RendererCache.applyFrame requires change_flags length ${packet.entity_count}, got ${flagCount}`,
+        );
+      }
+    }
 
     if (packet.frame_version != null && packet.frame_version === this.lastFrameVersion) {
       this._dirty = false;
@@ -174,7 +197,6 @@ export class RendererCache {
       parent_ids,
     } = packet;
     const changeFlags = packet.change_flags;
-    const hasChangeFlags = changeFlags !== undefined && changeFlags.length > 0;
     const instanceGroups = packet.instance_groups;
     const tints = packet.tints;
     // Entities that exited the instanced path this frame and need parent
@@ -187,7 +209,7 @@ export class RendererCache {
       const entityId = entity_ids[i]!;
       const generation = entity_generations[i]!;
       activeIds.add(entityId);
-      const flag = hasChangeFlags ? changeFlags[i]! : 0xff;
+      const flag = isIncremental ? changeFlags![i]! : 0xff;
 
       // ----- Instanced routing -----
       // Entities tagged with `InstanceOf` skip the standalone-Object3D path
@@ -353,7 +375,7 @@ export class RendererCache {
     // extraction, so a forward pass correctly builds the hierarchy.
     for (let i = 0; i < packet.entity_count; i++) {
       const entityId = entity_ids[i]!;
-      const flag = hasChangeFlags ? changeFlags[i]! : 0xff;
+      const flag = isIncremental ? changeFlags![i]! : 0xff;
       const shouldReparent =
         (flag & CHANGED_PARENT) !== 0 || forceParentReconcile.has(entityId);
       if (!shouldReparent) continue;
@@ -386,7 +408,7 @@ export class RendererCache {
     // Remove objects for entities that disappeared this frame.
     // Skip for incremental packets — they only include changed entities,
     // so absence does NOT mean despawned.
-    if (!hasChangeFlags) {
+    if (!isIncremental) {
       for (const [id, obj] of this.objects) {
         if (!activeIds.has(id)) {
           this.removeEntity(id, obj);
@@ -406,6 +428,11 @@ export class RendererCache {
         this.clearDetachedChildrenHintsForParent(id);
       }
     }
+  }
+
+  /** Convenience wrapper for applying incremental delta packets. */
+  applyIncrementalFrame(packet: FramePacketView): void {
+    this.applyFrame(packet, { mode: "incremental" });
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -209,15 +209,23 @@ export class RendererHost<
     this.running = true;
     this.lastTimeMs = undefined;
 
-    if (this.adapter.setAnimationLoop !== undefined) {
-      this.adapter.setAnimationLoop((timeMs) => this.tick(timeMs));
-      return;
-    }
+    try {
+      if (this.adapter.setAnimationLoop !== undefined) {
+        this.adapter.setAnimationLoop((timeMs) => this.tick(timeMs));
+        return;
+      }
 
-    this.activeClock = this.resolveClock();
-    this.frameHandle = this.activeClock.requestFrame((timeMs) =>
-      this.tick(timeMs),
-    );
+      this.activeClock = this.resolveClock();
+      this.frameHandle = this.activeClock.requestFrame((timeMs) =>
+        this.tick(timeMs),
+      );
+    } catch (error) {
+      this.running = false;
+      this.activeClock = undefined;
+      this.frameHandle = undefined;
+      this.lastTimeMs = undefined;
+      throw error;
+    }
   }
 
   /**

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -4,15 +4,38 @@ import * as THREE from "three";
 
 export type RendererHostBackend = "webgl" | "webgpu" | (string & {});
 
+/**
+ * Immutable per-frame context exposed to `onFrame` subscribers.
+ */
 export interface RendererHostFrame {
-  readonly host: RendererHost;
+  readonly hostId: string;
+  readonly backend: RendererHostBackend;
   readonly timeMs: number;
   readonly deltaMs: number;
+  readonly frameCount: number;
 }
 
-export interface RendererHostAdapter {
-  readonly backend: RendererHostBackend;
-  readonly renderer: unknown;
+export type RendererHostErrorPhase = "onFrame" | "render";
+
+/**
+ * Error context for failures that happen during the animation tick.
+ */
+export interface RendererHostErrorContext extends RendererHostFrame {
+  readonly phase: RendererHostErrorPhase;
+}
+
+/**
+ * Error callback for tick-level `onFrame` and `render` failures.
+ */
+export type RendererHostErrorHandler = (
+  error: unknown,
+  context: RendererHostErrorContext,
+) => void;
+
+/**
+ * Minimal renderer surface used by the host.
+ */
+export interface RendererHostRenderer {
   readonly domElement: HTMLCanvasElement;
   render(scene: THREE.Scene, camera: THREE.Camera): void;
   setSize?(width: number, height: number, updateStyle?: boolean): void;
@@ -20,22 +43,54 @@ export interface RendererHostAdapter {
   dispose?(): void;
 }
 
-export interface RendererHostClock {
-  requestFrame(callback: (timeMs: number) => void): unknown;
-  cancelFrame(handle: unknown): void;
+/**
+ * Host adapter around WebGL/WebGPU renderers.
+ */
+export interface RendererHostAdapter<
+  TRenderer extends RendererHostRenderer = RendererHostRenderer,
+> {
+  readonly backend: RendererHostBackend;
+  readonly renderer: TRenderer;
+  readonly domElement: HTMLCanvasElement;
+  render(scene: THREE.Scene, camera: THREE.Camera): void;
+  setSize?(width: number, height: number, updateStyle?: boolean): void;
+  setAnimationLoop?(callback: ((timeMs: number) => void) | null): void;
+  dispose?(): void;
+}
+
+/**
+ * Animation-frame clock abstraction for browser and tests.
+ */
+export interface RendererHostClock<TFrameHandle = number> {
+  requestFrame(callback: (timeMs: number) => void): TFrameHandle;
+  cancelFrame(handle: TFrameHandle): void;
   now?(): number;
 }
 
-export interface RendererHostOptions {
-  readonly adapter: RendererHostAdapter;
+/**
+ * Renderer host configuration.
+ */
+export interface RendererHostOptions<
+  TRenderer extends RendererHostRenderer = RendererHostRenderer,
+  TFrameHandle = number,
+> {
+  readonly adapter: RendererHostAdapter<TRenderer>;
   readonly scene?: THREE.Scene;
   readonly camera?: THREE.Camera;
-  readonly clock?: RendererHostClock;
+  readonly clock?: RendererHostClock<TFrameHandle>;
   readonly autoRender?: boolean;
   readonly onFrame?: (frame: RendererHostFrame) => void;
+  /**
+   * Called when `onFrame` or `adapter.render` throws during a tick.
+   *
+   * The host keeps running after reporting the error unless user code
+   * explicitly calls `stop()` or `dispose()`.
+   */
+  readonly onError?: RendererHostErrorHandler;
 }
 
-let nextRendererHostId = 1;
+const RENDERER_HOST_ID_PREFIX = "galeon-renderer-host";
+let fallbackRendererHostId = 1;
 
 /**
  * Owns renderer/canvas lifecycle independently from UI component state.
@@ -43,68 +98,108 @@ let nextRendererHostId = 1;
  * UI shells can attach/detach the host canvas and subscribe to frames, but
  * ordinary UI state changes should not recreate this object or its renderer.
  */
-export class RendererHost {
-  readonly id = `galeon-renderer-host-${nextRendererHostId++}`;
+export class RendererHost<
+  TRenderer extends RendererHostRenderer = RendererHostRenderer,
+  TFrameHandle = number,
+> {
+  readonly id = createRendererHostId();
   readonly scene: THREE.Scene;
   readonly camera: THREE.Camera;
-  readonly adapter: RendererHostAdapter;
+  readonly adapter: RendererHostAdapter<TRenderer>;
 
-  private readonly clock: RendererHostClock;
+  private readonly clock: RendererHostClock<TFrameHandle>;
   private readonly autoRender: boolean;
   private readonly onFrame?: (frame: RendererHostFrame) => void;
-  private frameHandle: unknown;
+  private readonly onError: RendererHostErrorHandler;
+  private frameHandle: TFrameHandle | undefined;
   private running = false;
   private disposed = false;
   private lastTimeMs: number | undefined;
   private _frameCount = 0;
 
-  constructor(options: RendererHostOptions) {
+  /**
+   * Create a renderer host around a specific renderer adapter.
+   */
+  constructor(options: RendererHostOptions<TRenderer, TFrameHandle>) {
     this.adapter = options.adapter;
     this.scene = options.scene ?? new THREE.Scene();
     this.camera = options.camera ?? new THREE.PerspectiveCamera();
-    this.clock = options.clock ?? browserFrameClock();
+    this.clock = (options.clock ?? browserFrameClock()) as RendererHostClock<TFrameHandle>;
     this.autoRender = options.autoRender ?? true;
     this.onFrame = options.onFrame;
+    this.onError = options.onError ?? defaultRendererHostErrorHandler;
   }
 
+  /**
+   * Canvas owned by this host.
+   */
   get canvas(): HTMLCanvasElement {
     return this.adapter.domElement;
   }
 
+  /**
+   * Backend identity declared by the adapter.
+   */
   get backend(): RendererHostBackend {
     return this.adapter.backend;
   }
 
-  get rendererIdentity(): unknown {
+  /**
+   * Stable adapter renderer instance identity.
+   */
+  get rendererIdentity(): TRenderer {
     return this.adapter.renderer;
   }
 
+  /**
+   * Indicates whether the tick loop is active.
+   */
   get isRunning(): boolean {
     return this.running;
   }
 
+  /**
+   * Number of processed frames since host construction.
+   */
   get frameCount(): number {
     return this._frameCount;
   }
 
+  /**
+   * Attach the host canvas to a parent DOM node.
+   */
   attachTo(parent: HTMLElement): void {
     this.assertNotDisposed();
     if (this.canvas.parentElement === parent) {
       return;
     }
+    if (!parent.isConnected) {
+      console.warn(
+        `[RendererHost:${this.id}] attachTo() received a detached parent; canvas remains off-document until the parent is connected`,
+      );
+    }
     this.canvas.parentElement?.removeChild(this.canvas);
     parent.appendChild(this.canvas);
   }
 
+  /**
+   * Remove the host canvas from its current parent.
+   */
   detach(): void {
     this.canvas.parentElement?.removeChild(this.canvas);
   }
 
+  /**
+   * Resize the renderer surface.
+   */
   setSize(width: number, height: number, updateStyle = true): void {
     this.assertNotDisposed();
     this.adapter.setSize?.(width, height, updateStyle);
   }
 
+  /**
+   * Start the renderer tick loop.
+   */
   start(): void {
     this.assertNotDisposed();
     if (this.running) {
@@ -123,6 +218,9 @@ export class RendererHost {
     );
   }
 
+  /**
+   * Stop the renderer tick loop.
+   */
   stop(): void {
     if (!this.running) {
       return;
@@ -138,11 +236,17 @@ export class RendererHost {
     }
   }
 
+  /**
+   * Render the current scene once.
+   */
   render(): void {
     this.assertNotDisposed();
     this.adapter.render(this.scene, this.camera);
   }
 
+  /**
+   * Stop the loop, detach the canvas, and dispose adapter resources.
+   */
   dispose(): void {
     if (this.disposed) {
       return;
@@ -154,7 +258,7 @@ export class RendererHost {
   }
 
   private tick(timeMs: number): void {
-    if (!this.running) {
+    if (!this.running || this.disposed) {
       return;
     }
 
@@ -162,15 +266,58 @@ export class RendererHost {
       this.lastTimeMs === undefined ? 0 : Math.max(0, timeMs - this.lastTimeMs);
     this.lastTimeMs = timeMs;
     this._frameCount += 1;
-    this.onFrame?.({ host: this, timeMs, deltaMs });
-    if (this.autoRender) {
-      this.render();
+    const frame = this.createFrame(timeMs, deltaMs);
+
+    if (this.onFrame !== undefined) {
+      try {
+        this.onFrame(frame);
+      } catch (error) {
+        this.reportError(error, "onFrame", frame);
+      }
     }
 
-    if (this.running && this.adapter.setAnimationLoop === undefined) {
+    if (!this.running || this.disposed) {
+      return;
+    }
+
+    if (this.autoRender) {
+      try {
+        this.render();
+      } catch (error) {
+        this.reportError(error, "render", frame);
+      }
+    }
+
+    if (
+      this.running &&
+      !this.disposed &&
+      this.adapter.setAnimationLoop === undefined
+    ) {
       this.frameHandle = this.clock.requestFrame((nextTimeMs) =>
         this.tick(nextTimeMs),
       );
+    }
+  }
+
+  private createFrame(timeMs: number, deltaMs: number): RendererHostFrame {
+    return {
+      hostId: this.id,
+      backend: this.backend,
+      timeMs,
+      deltaMs,
+      frameCount: this._frameCount,
+    };
+  }
+
+  private reportError(
+    error: unknown,
+    phase: RendererHostErrorPhase,
+    frame: RendererHostFrame,
+  ): void {
+    try {
+      this.onError(error, { ...frame, phase });
+    } catch (handlerError) {
+      defaultRendererHostErrorHandler(handlerError, { ...frame, phase });
     }
   }
 
@@ -181,16 +328,12 @@ export class RendererHost {
   }
 }
 
-export function createThreeRendererHostAdapter(
+export function createThreeRendererHostAdapter<
+  TRenderer extends RendererHostRenderer,
+>(
   backend: RendererHostBackend,
-  renderer: {
-    readonly domElement: HTMLCanvasElement;
-    render(scene: THREE.Scene, camera: THREE.Camera): void;
-    setSize?(width: number, height: number, updateStyle?: boolean): void;
-    setAnimationLoop?(callback: ((timeMs: number) => void) | null): void;
-    dispose?(): void;
-  },
-): RendererHostAdapter {
+  renderer: TRenderer,
+): RendererHostAdapter<TRenderer> {
   return {
     backend,
     renderer,
@@ -202,7 +345,7 @@ export function createThreeRendererHostAdapter(
   };
 }
 
-function browserFrameClock(): RendererHostClock {
+function browserFrameClock(): RendererHostClock<number> {
   const raf = globalThis.requestAnimationFrame;
   const caf = globalThis.cancelAnimationFrame;
   if (raf === undefined || caf === undefined) {
@@ -215,4 +358,22 @@ function browserFrameClock(): RendererHostClock {
     cancelFrame: (handle) => caf(handle as number),
     now: () => performance.now(),
   };
+}
+
+function createRendererHostId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID;
+  if (typeof randomUuid === "function") {
+    return `${RENDERER_HOST_ID_PREFIX}-${randomUuid.call(globalThis.crypto)}`;
+  }
+  return `${RENDERER_HOST_ID_PREFIX}-${fallbackRendererHostId++}`;
+}
+
+function defaultRendererHostErrorHandler(
+  error: unknown,
+  context: RendererHostErrorContext,
+): void {
+  console.error(
+    `[RendererHost:${context.hostId}] ${context.phase} failed on frame ${context.frameCount} (${context.backend}) at ${context.timeMs}ms (delta ${context.deltaMs}ms)`,
+    error,
+  );
 }

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -107,7 +107,8 @@ export class RendererHost<
   readonly camera: THREE.Camera;
   readonly adapter: RendererHostAdapter<TRenderer>;
 
-  private readonly clock: RendererHostClock<TFrameHandle>;
+  private readonly clock?: RendererHostClock<TFrameHandle>;
+  private activeClock?: RendererHostClock<TFrameHandle>;
   private readonly autoRender: boolean;
   private readonly onFrame?: (frame: RendererHostFrame) => void;
   private readonly onError: RendererHostErrorHandler;
@@ -124,7 +125,7 @@ export class RendererHost<
     this.adapter = options.adapter;
     this.scene = options.scene ?? new THREE.Scene();
     this.camera = options.camera ?? new THREE.PerspectiveCamera();
-    this.clock = (options.clock ?? browserFrameClock()) as RendererHostClock<TFrameHandle>;
+    this.clock = options.clock;
     this.autoRender = options.autoRender ?? true;
     this.onFrame = options.onFrame;
     this.onError = options.onError ?? defaultRendererHostErrorHandler;
@@ -213,7 +214,8 @@ export class RendererHost<
       return;
     }
 
-    this.frameHandle = this.clock.requestFrame((timeMs) =>
+    this.activeClock = this.resolveClock();
+    this.frameHandle = this.activeClock.requestFrame((timeMs) =>
       this.tick(timeMs),
     );
   }
@@ -231,9 +233,10 @@ export class RendererHost<
       this.adapter.setAnimationLoop(null);
     }
     if (this.frameHandle !== undefined) {
-      this.clock.cancelFrame(this.frameHandle);
+      this.activeClock?.cancelFrame(this.frameHandle);
       this.frameHandle = undefined;
     }
+    this.activeClock = undefined;
   }
 
   /**
@@ -293,10 +296,16 @@ export class RendererHost<
       !this.disposed &&
       this.adapter.setAnimationLoop === undefined
     ) {
-      this.frameHandle = this.clock.requestFrame((nextTimeMs) =>
+      const clock = this.activeClock ?? this.resolveClock();
+      this.activeClock = clock;
+      this.frameHandle = clock.requestFrame((nextTimeMs) =>
         this.tick(nextTimeMs),
       );
     }
+  }
+
+  private resolveClock(): RendererHostClock<TFrameHandle> {
+    return (this.clock ?? browserFrameClock()) as RendererHostClock<TFrameHandle>;
   }
 
   private createFrame(timeMs: number, deltaMs: number): RendererHostFrame {

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import * as THREE from "three";
+
+export type RendererHostBackend = "webgl" | "webgpu" | (string & {});
+
+export interface RendererHostFrame {
+  readonly host: RendererHost;
+  readonly timeMs: number;
+  readonly deltaMs: number;
+}
+
+export interface RendererHostAdapter {
+  readonly backend: RendererHostBackend;
+  readonly renderer: unknown;
+  readonly domElement: HTMLCanvasElement;
+  render(scene: THREE.Scene, camera: THREE.Camera): void;
+  setSize?(width: number, height: number, updateStyle?: boolean): void;
+  setAnimationLoop?(callback: ((timeMs: number) => void) | null): void;
+  dispose?(): void;
+}
+
+export interface RendererHostClock {
+  requestFrame(callback: (timeMs: number) => void): unknown;
+  cancelFrame(handle: unknown): void;
+  now?(): number;
+}
+
+export interface RendererHostOptions {
+  readonly adapter: RendererHostAdapter;
+  readonly scene?: THREE.Scene;
+  readonly camera?: THREE.Camera;
+  readonly clock?: RendererHostClock;
+  readonly autoRender?: boolean;
+  readonly onFrame?: (frame: RendererHostFrame) => void;
+}
+
+let nextRendererHostId = 1;
+
+/**
+ * Owns renderer/canvas lifecycle independently from UI component state.
+ *
+ * UI shells can attach/detach the host canvas and subscribe to frames, but
+ * ordinary UI state changes should not recreate this object or its renderer.
+ */
+export class RendererHost {
+  readonly id = `galeon-renderer-host-${nextRendererHostId++}`;
+  readonly scene: THREE.Scene;
+  readonly camera: THREE.Camera;
+  readonly adapter: RendererHostAdapter;
+
+  private readonly clock: RendererHostClock;
+  private readonly autoRender: boolean;
+  private readonly onFrame?: (frame: RendererHostFrame) => void;
+  private frameHandle: unknown;
+  private running = false;
+  private disposed = false;
+  private lastTimeMs: number | undefined;
+  private _frameCount = 0;
+
+  constructor(options: RendererHostOptions) {
+    this.adapter = options.adapter;
+    this.scene = options.scene ?? new THREE.Scene();
+    this.camera = options.camera ?? new THREE.PerspectiveCamera();
+    this.clock = options.clock ?? browserFrameClock();
+    this.autoRender = options.autoRender ?? true;
+    this.onFrame = options.onFrame;
+  }
+
+  get canvas(): HTMLCanvasElement {
+    return this.adapter.domElement;
+  }
+
+  get backend(): RendererHostBackend {
+    return this.adapter.backend;
+  }
+
+  get rendererIdentity(): unknown {
+    return this.adapter.renderer;
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  get frameCount(): number {
+    return this._frameCount;
+  }
+
+  attachTo(parent: HTMLElement): void {
+    this.assertNotDisposed();
+    if (this.canvas.parentElement === parent) {
+      return;
+    }
+    this.canvas.parentElement?.removeChild(this.canvas);
+    parent.appendChild(this.canvas);
+  }
+
+  detach(): void {
+    this.canvas.parentElement?.removeChild(this.canvas);
+  }
+
+  setSize(width: number, height: number, updateStyle = true): void {
+    this.assertNotDisposed();
+    this.adapter.setSize?.(width, height, updateStyle);
+  }
+
+  start(): void {
+    this.assertNotDisposed();
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.lastTimeMs = undefined;
+
+    if (this.adapter.setAnimationLoop !== undefined) {
+      this.adapter.setAnimationLoop((timeMs) => this.tick(timeMs));
+      return;
+    }
+
+    this.frameHandle = this.clock.requestFrame((timeMs) =>
+      this.tick(timeMs),
+    );
+  }
+
+  stop(): void {
+    if (!this.running) {
+      return;
+    }
+    this.running = false;
+
+    if (this.adapter.setAnimationLoop !== undefined) {
+      this.adapter.setAnimationLoop(null);
+    }
+    if (this.frameHandle !== undefined) {
+      this.clock.cancelFrame(this.frameHandle);
+      this.frameHandle = undefined;
+    }
+  }
+
+  render(): void {
+    this.assertNotDisposed();
+    this.adapter.render(this.scene, this.camera);
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.stop();
+    this.detach();
+    this.adapter.dispose?.();
+    this.disposed = true;
+  }
+
+  private tick(timeMs: number): void {
+    if (!this.running) {
+      return;
+    }
+
+    const deltaMs =
+      this.lastTimeMs === undefined ? 0 : Math.max(0, timeMs - this.lastTimeMs);
+    this.lastTimeMs = timeMs;
+    this._frameCount += 1;
+    this.onFrame?.({ host: this, timeMs, deltaMs });
+    if (this.autoRender) {
+      this.render();
+    }
+
+    if (this.running && this.adapter.setAnimationLoop === undefined) {
+      this.frameHandle = this.clock.requestFrame((nextTimeMs) =>
+        this.tick(nextTimeMs),
+      );
+    }
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new Error("RendererHost has been disposed");
+    }
+  }
+}
+
+export function createThreeRendererHostAdapter(
+  backend: RendererHostBackend,
+  renderer: {
+    readonly domElement: HTMLCanvasElement;
+    render(scene: THREE.Scene, camera: THREE.Camera): void;
+    setSize?(width: number, height: number, updateStyle?: boolean): void;
+    setAnimationLoop?(callback: ((timeMs: number) => void) | null): void;
+    dispose?(): void;
+  },
+): RendererHostAdapter {
+  return {
+    backend,
+    renderer,
+    domElement: renderer.domElement,
+    render: (scene, camera) => renderer.render(scene, camera),
+    setSize: renderer.setSize?.bind(renderer),
+    setAnimationLoop: renderer.setAnimationLoop?.bind(renderer),
+    dispose: renderer.dispose?.bind(renderer),
+  };
+}
+
+function browserFrameClock(): RendererHostClock {
+  const raf = globalThis.requestAnimationFrame;
+  const caf = globalThis.cancelAnimationFrame;
+  if (raf === undefined || caf === undefined) {
+    throw new Error(
+      "RendererHost requires a clock outside browser animation-frame environments",
+    );
+  }
+  return {
+    requestFrame: (callback) => raf(callback),
+    cancelFrame: (handle) => caf(handle as number),
+    now: () => performance.now(),
+  };
+}

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -223,8 +223,11 @@ export class RendererHost<
       if (this.adapter.setAnimationLoop !== undefined) {
         try {
           this.adapter.setAnimationLoop(null);
-        } catch {
-          // Preserve and rethrow the original start failure.
+        } catch (rollbackError) {
+          console.warn(
+            `[RendererHost:${this.id}] start() rollback failed while clearing animation loop`,
+            rollbackError,
+          );
         }
       }
       this.running = false;
@@ -243,15 +246,29 @@ export class RendererHost<
       return;
     }
     this.running = false;
+    const errors: unknown[] = [];
 
     if (this.adapter.setAnimationLoop !== undefined) {
-      this.adapter.setAnimationLoop(null);
+      try {
+        this.adapter.setAnimationLoop(null);
+      } catch (error) {
+        errors.push(error);
+      }
     }
     if (this.frameHandle !== undefined) {
-      this.activeClock?.cancelFrame(this.frameHandle);
-      this.frameHandle = undefined;
+      try {
+        this.activeClock?.cancelFrame(this.frameHandle);
+      } catch (error) {
+        errors.push(error);
+      } finally {
+        this.frameHandle = undefined;
+      }
     }
     this.activeClock = undefined;
+    this.lastTimeMs = undefined;
+    if (errors.length > 0) {
+      throw errors[0];
+    }
   }
 
   /**
@@ -269,15 +286,39 @@ export class RendererHost<
     if (this.disposed) {
       return;
     }
-    this.stop();
-    this.detach();
-    this.adapter.dispose?.();
     this.disposed = true;
+    const errors: unknown[] = [];
+
+    try {
+      this.stop();
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
+      this.detach();
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
+      this.adapter.dispose?.();
+    } catch (error) {
+      errors.push(error);
+    }
+
+    if (errors.length > 0) {
+      throw errors[0];
+    }
   }
 
   private tick(timeMs: number): void {
     if (!this.running || this.disposed) {
       return;
+    }
+    if (this.adapter.setAnimationLoop === undefined) {
+      // The current fallback frame callback has been consumed.
+      this.frameHandle = undefined;
     }
 
     const deltaMs =
@@ -309,7 +350,8 @@ export class RendererHost<
     if (
       this.running &&
       !this.disposed &&
-      this.adapter.setAnimationLoop === undefined
+      this.adapter.setAnimationLoop === undefined &&
+      this.frameHandle === undefined
     ) {
       const clock = this.activeClock ?? this.resolveClock();
       this.activeClock = clock;
@@ -338,10 +380,15 @@ export class RendererHost<
     phase: RendererHostErrorPhase,
     frame: RendererHostFrame,
   ): void {
+    const context = { ...frame, phase };
     try {
-      this.onError(error, { ...frame, phase });
+      this.onError(error, context);
     } catch (handlerError) {
-      defaultRendererHostErrorHandler(handlerError, { ...frame, phase });
+      defaultRendererHostErrorHandler(error, context);
+      console.error(
+        `[RendererHost:${context.hostId}] onError handler failed while reporting ${context.phase} error`,
+        handlerError,
+      );
     }
   }
 

--- a/packages/three/src/renderer-host.ts
+++ b/packages/three/src/renderer-host.ts
@@ -220,6 +220,13 @@ export class RendererHost<
         this.tick(timeMs),
       );
     } catch (error) {
+      if (this.adapter.setAnimationLoop !== undefined) {
+        try {
+          this.adapter.setAnimationLoop(null);
+        } catch {
+          // Preserve and rethrow the original start failure.
+        }
+      }
       this.running = false;
       this.activeClock = undefined;
       this.frameHandle = undefined;

--- a/packages/three/tests/instanced-mesh.test.ts
+++ b/packages/three/tests/instanced-mesh.test.ts
@@ -188,7 +188,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f2 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f2);
+    cache.applyIncrementalFrame(f2);
 
     expect(cache.instancing.has(42)).toBe(false);
     expect(cache.instancing.slotsFor(2)).toBe(0);
@@ -228,7 +228,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f2 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f2);
+    cache.applyIncrementalFrame(f2);
 
     const childObj = cache.getObject(42, 0);
     expect(childObj).toBeDefined();
@@ -270,7 +270,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f2 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f2);
+    cache.applyIncrementalFrame(f2);
 
     const childDetached = cache.getObject(200, 0);
     expect(childDetached).toBeDefined();
@@ -287,7 +287,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f3 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f3);
+    cache.applyIncrementalFrame(f3);
 
     const parentAfter = cache.getObject(100, 0);
     const childAfter = cache.getObject(200, 0);
@@ -329,7 +329,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f2 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_PARENT | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f2);
+    cache.applyIncrementalFrame(f2);
 
     const childWhileParentInstanced = cache.getObject(200, 0);
     expect(childWhileParentInstanced).toBeDefined();
@@ -346,7 +346,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f3 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP | CHANGED_TRANSFORM,
     ]);
-    cache.applyFrame(f3);
+    cache.applyIncrementalFrame(f3);
 
     const parentAfter = cache.getObject(100, 0);
     const childAfter = cache.getObject(200, 0);
@@ -392,6 +392,70 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     }
   });
 
+  test("full-mode empty packets evict absent entities even with empty change_flags", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const fullFrame = makePacket({ entity_count: 1 });
+    fillIdentityTransforms(fullFrame);
+    fullFrame.entity_ids[0] = 42;
+    fullFrame.mesh_handles[0] = 7;
+    cache.applyFrame(fullFrame);
+    expect(cache.objectCount).toBe(1);
+
+    const emptyWithFlags = makePacket({
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+    });
+    cache.applyFrame(emptyWithFlags);
+    expect(cache.objectCount).toBe(0);
+  });
+
+  test("explicit empty incremental packet preserves cached entities", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const fullFrame = makePacket({ entity_count: 1 });
+    fillIdentityTransforms(fullFrame);
+    fullFrame.entity_ids[0] = 42;
+    fullFrame.mesh_handles[0] = 7;
+    cache.applyFrame(fullFrame);
+    expect(cache.getObject(42, 0)).toBeDefined();
+
+    const emptyIncremental = makePacket({
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+    });
+    cache.applyIncrementalFrame(emptyIncremental);
+
+    expect(cache.objectCount).toBe(1);
+    expect(cache.getObject(42, 0)).toBeDefined();
+  });
+
+  test("non-empty incremental packets require per-row change flags", () => {
+    const scene = new THREE.Scene();
+    const cache = new RendererCache(scene);
+    cache.registerGeometry(7, new THREE.BoxGeometry(1, 1, 1));
+    cache.registerMaterial(0, new THREE.MeshBasicMaterial());
+
+    const packet = makePacket({
+      entity_count: 1,
+      change_flags: new Uint8Array(0),
+    });
+    fillIdentityTransforms(packet);
+    packet.entity_ids[0] = 42;
+    packet.mesh_handles[0] = 7;
+
+    expect(() => cache.applyIncrementalFrame(packet)).toThrow(
+      "incremental RendererCache.applyFrame requires change_flags length 1, got 0",
+    );
+    expect(cache.objectCount).toBe(0);
+  });
+
   test("CHANGED_INSTANCE_GROUP migrates entity between batches", () => {
     const scene = new THREE.Scene();
     const cache = new RendererCache(scene);
@@ -418,7 +482,7 @@ describe("RendererCache instanced-mesh path (#215 T2)", () => {
     (f2 as { change_flags?: Uint8Array }).change_flags = new Uint8Array([
       CHANGED_INSTANCE_GROUP,
     ]);
-    cache.applyFrame(f2);
+    cache.applyIncrementalFrame(f2);
 
     expect(cache.instancing.slotsFor(10)).toBe(0);
     expect(cache.instancing.slotsFor(11)).toBe(1);

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -40,6 +40,7 @@ function makeRenderer() {
     render: 0,
     dispose: 0,
     setSize: 0,
+    setSizeArgs: [] as Array<[number, number, boolean | undefined]>,
   };
   return {
     calls,
@@ -51,9 +52,56 @@ function makeRenderer() {
       dispose: () => {
         calls.dispose += 1;
       },
-      setSize: () => {
+      setSize: (width: number, height: number, updateStyle?: boolean) => {
         calls.setSize += 1;
+        calls.setSizeArgs.push([width, height, updateStyle]);
       },
+    },
+  };
+}
+
+function createMockCanvas(): HTMLCanvasElement {
+  return {
+    parentElement: null as HTMLElement | null,
+  } as HTMLCanvasElement;
+}
+
+function createMockParent(options?: { isConnected?: boolean; removeError?: Error }) {
+  const children: HTMLCanvasElement[] = [];
+  let appendCalls = 0;
+  let removeCalls = 0;
+
+  const parent = {
+    isConnected: options?.isConnected ?? true,
+    appendChild: (child: HTMLCanvasElement) => {
+      appendCalls += 1;
+      (child as { parentElement: HTMLElement | null }).parentElement =
+        parent as unknown as HTMLElement;
+      children.push(child);
+      return child;
+    },
+    removeChild: (child: HTMLCanvasElement) => {
+      removeCalls += 1;
+      if (options?.removeError !== undefined) {
+        throw options.removeError;
+      }
+      const index = children.indexOf(child);
+      if (index >= 0) {
+        children.splice(index, 1);
+      }
+      (child as { parentElement: HTMLElement | null }).parentElement = null;
+      return child;
+    },
+  };
+
+  return {
+    parent: parent as unknown as HTMLElement,
+    children,
+    get appendCalls(): number {
+      return appendCalls;
+    },
+    get removeCalls(): number {
+      return removeCalls;
     },
   };
 }
@@ -78,6 +126,54 @@ describe("RendererHost", () => {
     expect(host.rendererIdentity).toBe(identity);
     expect(host.frameCount).toBe(3);
     expect(calls.render).toBe(3);
+  });
+
+  test("attachTo and detach move the canvas across parents without duplicates", () => {
+    const canvas = createMockCanvas();
+    const parentA = createMockParent();
+    const parentB = createMockParent();
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", {
+        domElement: canvas,
+        render: () => {},
+      }),
+    });
+
+    host.attachTo(parentA.parent);
+    expect(parentA.children).toEqual([canvas]);
+    expect(parentA.appendCalls).toBe(1);
+    expect(parentA.removeCalls).toBe(0);
+
+    host.attachTo(parentA.parent);
+    expect(parentA.children).toEqual([canvas]);
+    expect(parentA.appendCalls).toBe(1);
+    expect(parentA.removeCalls).toBe(0);
+
+    host.attachTo(parentB.parent);
+    expect(parentA.children).toEqual([]);
+    expect(parentA.removeCalls).toBe(1);
+    expect(parentB.children).toEqual([canvas]);
+    expect(parentB.appendCalls).toBe(1);
+
+    host.detach();
+    expect(parentB.children).toEqual([]);
+    expect(parentB.removeCalls).toBe(1);
+  });
+
+  test("setSize forwards width, height, and updateStyle", () => {
+    const { calls, renderer } = makeRenderer();
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", renderer),
+    });
+
+    host.setSize(320, 200, false);
+    host.setSize(640, 480);
+
+    expect(calls.setSize).toBe(2);
+    expect(calls.setSizeArgs).toEqual([
+      [320, 200, false],
+      [640, 480, true],
+    ]);
   });
 
   test("dispose stops the loop and disposes the renderer once", () => {
@@ -120,6 +216,36 @@ describe("RendererHost", () => {
     expect(clock.pendingCount()).toBe(0);
     expect(calls.render).toBe(0);
     expect(calls.dispose).toBe(1);
+  });
+
+  test("stop and start inside onFrame keep a single pending frame", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    let restarted = false;
+    let host!: RendererHost<typeof renderer, number>;
+    host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", renderer),
+      clock,
+      onFrame: () => {
+        if (!restarted) {
+          restarted = true;
+          host.stop();
+          host.start();
+        }
+      },
+    });
+
+    host.start();
+    expect(clock.pendingCount()).toBe(1);
+    clock.flush(0);
+    expect(clock.pendingCount()).toBe(1);
+    clock.flush(16);
+
+    expect(host.frameCount).toBe(2);
+    expect(calls.render).toBe(2);
+
+    host.stop();
+    expect(clock.pendingCount()).toBe(0);
   });
 
   test("reports onFrame errors and keeps the loop running", () => {
@@ -199,6 +325,44 @@ describe("RendererHost", () => {
     ]);
 
     host.stop();
+  });
+
+  test("onError handler failures still report the original tick error", () => {
+    const clock = new ManualClock();
+    const { renderer } = makeRenderer();
+    const renderFailure = new Error("render failure");
+    const handlerFailure = new Error("handler failure");
+    renderer.render = () => {
+      throw renderFailure;
+    };
+    const logs: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      logs.push(args);
+    };
+
+    try {
+      const host = new RendererHost({
+        adapter: createThreeRendererHostAdapter("webgpu", renderer),
+        clock,
+        onError: () => {
+          throw handlerFailure;
+        },
+      });
+
+      host.start();
+      clock.flush(0);
+      host.stop();
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0]?.[1]).toBe(renderFailure);
+      expect(logs[1]?.[0]).toContain(
+        "onError handler failed while reporting render error",
+      );
+      expect(logs[1]?.[1]).toBe(handlerFailure);
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 
   test("start wires setAnimationLoop callback and stop clears it", () => {
@@ -288,6 +452,57 @@ describe("RendererHost", () => {
     }
   });
 
+  test("fallback clock start can recover once animation-frame globals are restored", () => {
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const originalRequestAnimationFrame = globals.requestAnimationFrame;
+    const originalCancelAnimationFrame = globals.cancelAnimationFrame;
+    const scheduled = new Map<number, (timeMs: number) => void>();
+    let nextHandle = 1;
+
+    try {
+      const { calls, renderer } = makeRenderer();
+      const host = new RendererHost({
+        adapter: createThreeRendererHostAdapter("webgl", renderer),
+      });
+
+      globals.requestAnimationFrame = undefined;
+      globals.cancelAnimationFrame = undefined;
+      expect(() => host.start()).toThrow(
+        "RendererHost requires a clock outside browser animation-frame environments",
+      );
+      expect(host.isRunning).toBe(false);
+
+      globals.requestAnimationFrame = (callback: (timeMs: number) => void) => {
+        const handle = nextHandle++;
+        scheduled.set(handle, callback);
+        return handle;
+      };
+      globals.cancelAnimationFrame = (handle: number) => {
+        scheduled.delete(handle);
+      };
+
+      host.start();
+      expect(host.isRunning).toBe(true);
+      expect(scheduled.size).toBe(1);
+
+      const handle = scheduled.keys().next().value as number | undefined;
+      expect(handle).toBeDefined();
+      const callback = scheduled.get(handle!);
+      scheduled.delete(handle!);
+      callback?.(12);
+
+      expect(host.frameCount).toBe(1);
+      expect(calls.render).toBe(1);
+
+      host.stop();
+      expect(host.isRunning).toBe(false);
+      expect(scheduled.size).toBe(0);
+    } finally {
+      globals.requestAnimationFrame = originalRequestAnimationFrame;
+      globals.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test("failed setAnimationLoop start clears the renderer loop", () => {
     const { calls, renderer } = makeRenderer();
     const failure = new Error("setAnimationLoop failed");
@@ -311,6 +526,87 @@ describe("RendererHost", () => {
     expect(callbacks).toHaveLength(2);
     expect(typeof callbacks[0]).toBe("function");
     expect(callbacks[1]).toBeNull();
+  });
+
+  test("failed setAnimationLoop rollback warns and preserves the original start failure", () => {
+    const { renderer } = makeRenderer();
+    const startFailure = new Error("setAnimationLoop failed");
+    const rollbackFailure = new Error("setAnimationLoop rollback failed");
+    const callbacks: Array<((timeMs: number) => void) | null> = [];
+    const warnings: unknown[][] = [];
+    const originalConsoleWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      const host = new RendererHost({
+        adapter: createThreeRendererHostAdapter("webgl", {
+          ...renderer,
+          setAnimationLoop: (callback) => {
+            callbacks.push(callback);
+            if (callback === null) {
+              throw rollbackFailure;
+            }
+            throw startFailure;
+          },
+        }),
+      });
+
+      expect(() => host.start()).toThrow(startFailure);
+      expect(host.isRunning).toBe(false);
+      expect(callbacks).toHaveLength(2);
+      expect(typeof callbacks[0]).toBe("function");
+      expect(callbacks[1]).toBeNull();
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.[0]).toContain(
+        "start() rollback failed while clearing animation loop",
+      );
+      expect(warnings[0]?.[1]).toBe(rollbackFailure);
+    } finally {
+      console.warn = originalConsoleWarn;
+    }
+  });
+
+  test("dispose attempts stop, detach, and adapter disposal when cleanup throws", () => {
+    const stopFailure = new Error("stop failed");
+    const detachFailure = new Error("detach failed");
+    const disposeFailure = new Error("dispose failed");
+    const canvas = createMockCanvas();
+    const parent = createMockParent({ removeError: detachFailure });
+    let disposeCalls = 0;
+    const setAnimationLoopCalls: Array<((timeMs: number) => void) | null> = [];
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", {
+        domElement: canvas,
+        render: () => {},
+        setAnimationLoop: (callback) => {
+          setAnimationLoopCalls.push(callback);
+          if (callback === null) {
+            throw stopFailure;
+          }
+        },
+        dispose: () => {
+          disposeCalls += 1;
+          throw disposeFailure;
+        },
+      }),
+    });
+
+    host.attachTo(parent.parent);
+    host.start();
+    expect(() => host.dispose()).toThrow(stopFailure);
+
+    expect(setAnimationLoopCalls).toHaveLength(2);
+    expect(typeof setAnimationLoopCalls[0]).toBe("function");
+    expect(setAnimationLoopCalls[1]).toBeNull();
+    expect(parent.removeCalls).toBe(1);
+    expect(disposeCalls).toBe(1);
+    expect(host.isRunning).toBe(false);
+    expect(() => host.start()).toThrow("RendererHost has been disposed");
+
+    // Already marked disposed even if cleanup threw.
+    expect(() => host.dispose()).not.toThrow();
   });
 
   test("post-dispose APIs that require active lifecycle throw", () => {

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -229,6 +229,40 @@ describe("RendererHost", () => {
     expect(callbacks[1]).toBeNull();
   });
 
+  test("setAnimationLoop adapters do not require browser frame globals", () => {
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const originalRequestAnimationFrame = globals.requestAnimationFrame;
+    const originalCancelAnimationFrame = globals.cancelAnimationFrame;
+    globals.requestAnimationFrame = undefined;
+    globals.cancelAnimationFrame = undefined;
+
+    try {
+      const { calls, renderer } = makeRenderer();
+      let callback: ((timeMs: number) => void) | null = null;
+
+      const host = new RendererHost({
+        adapter: createThreeRendererHostAdapter("webgpu", {
+          ...renderer,
+          setAnimationLoop: (nextCallback) => {
+            callback = nextCallback;
+          },
+        }),
+      });
+
+      host.start();
+      callback?.(8);
+
+      expect(host.frameCount).toBe(1);
+      expect(calls.render).toBe(1);
+
+      host.stop();
+      expect(callback).toBeNull();
+    } finally {
+      globals.requestAnimationFrame = originalRequestAnimationFrame;
+      globals.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test("post-dispose APIs that require active lifecycle throw", () => {
     const clock = new ManualClock();
     const { calls, renderer } = makeRenderer();

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only OR Commercial
+
+import { describe, expect, test } from "bun:test";
+import * as THREE from "three";
+import {
+  RendererHost,
+  createThreeRendererHostAdapter,
+  type RendererHostClock,
+} from "../src/index.js";
+
+class ManualClock implements RendererHostClock {
+  private callbacks = new Map<number, (timeMs: number) => void>();
+  private nextHandle = 1;
+
+  requestFrame(callback: (timeMs: number) => void): number {
+    const handle = this.nextHandle++;
+    this.callbacks.set(handle, callback);
+    return handle;
+  }
+
+  cancelFrame(handle: unknown): void {
+    this.callbacks.delete(handle as number);
+  }
+
+  flush(timeMs: number): void {
+    const callbacks = Array.from(this.callbacks.values());
+    this.callbacks.clear();
+    for (const callback of callbacks) {
+      callback(timeMs);
+    }
+  }
+}
+
+function makeRenderer() {
+  const calls = {
+    render: 0,
+    dispose: 0,
+  };
+  return {
+    calls,
+    renderer: {
+      domElement: {} as HTMLCanvasElement,
+      render: (_scene: THREE.Scene, _camera: THREE.Camera) => {
+        calls.render += 1;
+      },
+      dispose: () => {
+        calls.dispose += 1;
+      },
+    },
+  };
+}
+
+describe("RendererHost", () => {
+  test("keeps stable renderer identity across start and stop", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", renderer),
+      clock,
+    });
+
+    const identity = host.rendererIdentity;
+    host.start();
+    clock.flush(0);
+    clock.flush(16);
+    host.stop();
+    host.start();
+    clock.flush(32);
+
+    expect(host.rendererIdentity).toBe(identity);
+    expect(host.frameCount).toBe(3);
+    expect(calls.render).toBe(3);
+  });
+
+  test("dispose stops the loop and disposes the renderer once", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", renderer),
+      clock,
+    });
+
+    host.start();
+    host.dispose();
+    clock.flush(0);
+    host.dispose();
+
+    expect(host.isRunning).toBe(false);
+    expect(host.frameCount).toBe(0);
+    expect(calls.render).toBe(0);
+    expect(calls.dispose).toBe(1);
+  });
+});

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -288,6 +288,31 @@ describe("RendererHost", () => {
     }
   });
 
+  test("failed setAnimationLoop start clears the renderer loop", () => {
+    const { calls, renderer } = makeRenderer();
+    const failure = new Error("setAnimationLoop failed");
+    const callbacks: Array<((timeMs: number) => void) | null> = [];
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", {
+        ...renderer,
+        setAnimationLoop: (callback) => {
+          callbacks.push(callback);
+          if (callback !== null) {
+            throw failure;
+          }
+        },
+      }),
+    });
+
+    expect(() => host.start()).toThrow(failure);
+    expect(host.isRunning).toBe(false);
+    expect(host.frameCount).toBe(0);
+    expect(calls.render).toBe(0);
+    expect(callbacks).toHaveLength(2);
+    expect(typeof callbacks[0]).toBe("function");
+    expect(callbacks[1]).toBeNull();
+  });
+
   test("post-dispose APIs that require active lifecycle throw", () => {
     const clock = new ManualClock();
     const { calls, renderer } = makeRenderer();

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -8,7 +8,7 @@ import {
   type RendererHostClock,
 } from "../src/index.js";
 
-class ManualClock implements RendererHostClock {
+class ManualClock implements RendererHostClock<number> {
   private callbacks = new Map<number, (timeMs: number) => void>();
   private nextHandle = 1;
 
@@ -18,8 +18,8 @@ class ManualClock implements RendererHostClock {
     return handle;
   }
 
-  cancelFrame(handle: unknown): void {
-    this.callbacks.delete(handle as number);
+  cancelFrame(handle: number): void {
+    this.callbacks.delete(handle);
   }
 
   flush(timeMs: number): void {
@@ -29,12 +29,17 @@ class ManualClock implements RendererHostClock {
       callback(timeMs);
     }
   }
+
+  pendingCount(): number {
+    return this.callbacks.size;
+  }
 }
 
 function makeRenderer() {
   const calls = {
     render: 0,
     dispose: 0,
+    setSize: 0,
   };
   return {
     calls,
@@ -45,6 +50,9 @@ function makeRenderer() {
       },
       dispose: () => {
         calls.dispose += 1;
+      },
+      setSize: () => {
+        calls.setSize += 1;
       },
     },
   };
@@ -88,6 +96,155 @@ describe("RendererHost", () => {
     expect(host.isRunning).toBe(false);
     expect(host.frameCount).toBe(0);
     expect(calls.render).toBe(0);
+    expect(calls.dispose).toBe(1);
+  });
+
+  test("dispose during onFrame does not render or reschedule", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    let host!: RendererHost<typeof renderer, number>;
+    host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", renderer),
+      clock,
+      onFrame: () => {
+        host.dispose();
+      },
+    });
+
+    host.start();
+    clock.flush(5);
+    clock.flush(10);
+
+    expect(host.isRunning).toBe(false);
+    expect(host.frameCount).toBe(1);
+    expect(clock.pendingCount()).toBe(0);
+    expect(calls.render).toBe(0);
+    expect(calls.dispose).toBe(1);
+  });
+
+  test("reports onFrame errors and keeps the loop running", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    const failure = new Error("frame failure");
+    const errors: Array<{
+      error: unknown;
+      phase: string;
+      frameCount: number;
+      backend: string;
+    }> = [];
+
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", renderer),
+      clock,
+      onFrame: () => {
+        throw failure;
+      },
+      onError: (error, context) => {
+        errors.push({
+          error,
+          phase: context.phase,
+          frameCount: context.frameCount,
+          backend: context.backend,
+        });
+      },
+    });
+
+    host.start();
+    clock.flush(0);
+    clock.flush(16);
+    host.stop();
+
+    expect(host.frameCount).toBe(2);
+    expect(calls.render).toBe(2);
+    expect(errors).toEqual([
+      { error: failure, phase: "onFrame", frameCount: 1, backend: "webgpu" },
+      { error: failure, phase: "onFrame", frameCount: 2, backend: "webgpu" },
+    ]);
+  });
+
+  test("reports render errors and keeps the loop running", () => {
+    const clock = new ManualClock();
+    const { renderer } = makeRenderer();
+    const failure = new Error("render failure");
+    renderer.render = () => {
+      throw failure;
+    };
+    const errors: Array<{
+      error: unknown;
+      phase: string;
+      frameCount: number;
+    }> = [];
+
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", renderer),
+      clock,
+      onError: (error, context) => {
+        errors.push({
+          error,
+          phase: context.phase,
+          frameCount: context.frameCount,
+        });
+      },
+    });
+
+    host.start();
+    clock.flush(0);
+    clock.flush(16);
+
+    expect(host.isRunning).toBe(true);
+    expect(host.frameCount).toBe(2);
+    expect(errors).toEqual([
+      { error: failure, phase: "render", frameCount: 1 },
+      { error: failure, phase: "render", frameCount: 2 },
+    ]);
+
+    host.stop();
+  });
+
+  test("start wires setAnimationLoop callback and stop clears it", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    const callbacks: Array<((timeMs: number) => void) | null> = [];
+
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgl", {
+        ...renderer,
+        setAnimationLoop: (callback) => {
+          callbacks.push(callback);
+        },
+      }),
+      clock,
+    });
+
+    host.start();
+    expect(callbacks).toHaveLength(1);
+    expect(typeof callbacks[0]).toBe("function");
+    callbacks[0]?.(0);
+
+    expect(host.frameCount).toBe(1);
+    expect(calls.render).toBe(1);
+
+    host.stop();
+    expect(callbacks).toHaveLength(2);
+    expect(callbacks[1]).toBeNull();
+  });
+
+  test("post-dispose APIs that require active lifecycle throw", () => {
+    const clock = new ManualClock();
+    const { calls, renderer } = makeRenderer();
+    const host = new RendererHost({
+      adapter: createThreeRendererHostAdapter("webgpu", renderer),
+      clock,
+    });
+
+    host.dispose();
+
+    expect(() => host.start()).toThrow("RendererHost has been disposed");
+    expect(() => host.render()).toThrow("RendererHost has been disposed");
+    expect(() => host.setSize(320, 200)).toThrow(
+      "RendererHost has been disposed",
+    );
+    expect(calls.setSize).toBe(0);
     expect(calls.dispose).toBe(1);
   });
 });

--- a/packages/three/tests/renderer-host.test.ts
+++ b/packages/three/tests/renderer-host.test.ts
@@ -263,6 +263,31 @@ describe("RendererHost", () => {
     }
   });
 
+  test("failed fallback clock lookup leaves host stopped", () => {
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const originalRequestAnimationFrame = globals.requestAnimationFrame;
+    const originalCancelAnimationFrame = globals.cancelAnimationFrame;
+    globals.requestAnimationFrame = undefined;
+    globals.cancelAnimationFrame = undefined;
+
+    try {
+      const { calls, renderer } = makeRenderer();
+      const host = new RendererHost({
+        adapter: createThreeRendererHostAdapter("webgl", renderer),
+      });
+
+      expect(() => host.start()).toThrow(
+        "RendererHost requires a clock outside browser animation-frame environments",
+      );
+      expect(host.isRunning).toBe(false);
+      expect(host.frameCount).toBe(0);
+      expect(calls.render).toBe(0);
+    } finally {
+      globals.requestAnimationFrame = originalRequestAnimationFrame;
+      globals.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test("post-dispose APIs that require active lifecycle throw", () => {
     const clock = new ManualClock();
     const { calls, renderer } = makeRenderer();


### PR DESCRIPTION
<!-- shiplog:
kind: history
status: open
phase: review
readiness: approved
task_count: 2
tasks_complete: 2
max_tier: 3
updated_at: 2026-05-11T10:33:18Z
updated_by: claude/opus-4.7 (claude-code)
edit_kind: review-snapshot
-->

## Summary

- Added `RendererHost` in `@galeon/three` to own renderer/canvas lifecycle, stable renderer identity, animation loop start/stop, sizing, attachment, rendering, and disposal through backend-aware adapters.
- Added `StateInterpolationBuffer` and `TransformFrameIngestion` in `@galeon/render-core` to buffer authoritative state and sample `FramePacket` transforms at render time by stable `(entityId, generation)` ids.
- Addressed request-changes feedback around empty incremental packets, interpolation retention/perf, malformed transform safety, renderer-host disposal/error handling, `setAnimationLoop` coverage, public types, tests, and ADR documentation.
- Removed packet-shape mode inference for `change_flags`, made incremental ingestion explicit, filed #254 for producer-side frame extraction mode, fixed incremental generation rollover, deferred fallback RAF clock construction for `setAnimationLoop` adapters, and hardened both fallback and adapter-loop start rollback paths.
- Renamed the renderer-host lifecycle ADR to ADR 0004, made `RendererCache` mode explicit (`applyFrame` full / `applyIncrementalFrame` delta) with contract check, hardened `RendererHost` cleanup/rollback/error reporting, and closed prior review's test gaps.

Addresses #252 (completes T1, T2)

## Journey Timeline

- `bd6345a` `feat(#252/T1-T2): add renderer host and frame ingestion primitives`
  - Introduced the minimal lifecycle and frame smoothing primitives.
  - Added focused tests for stable renderer identity, disposal behavior, interpolation, incremental-frame handling, and full-frame eviction.
- `e5a04c5` `fix(#252/T1-T2): address renderer lifecycle review feedback`
  - Fixed review blockers and follow-ups from the signed request-changes review.
  - Added ADR-0002 for the lifecycle boundary.
  - Expanded tests for empty incremental frames, bounded interpolation history, malformed transforms, visibility, generation rollover, quaternion sign flip, `setAnimationLoop`, error reporting, and disposal safety.
- `ad97335` `fix(#252/T2): make frame ingestion mode explicit`
  - Removed public packet-shape mode inference.
  - Kept empty `change_flags` valid for full WASM packets.
  - Added explicit incremental ingestion mode for ambiguous empty delta packets.
  - Filed #254 for producer-side frame extraction mode in the packet ABI.
- `57b7d40` `fix(#252/T2): evict stale generations during incremental ingestion`
  - Drops prior generation keys for the same entity id when an incremental row introduces a new generation.
  - Adds regression coverage so `sampleFrame()` and `sampleEntity(oldGeneration)` cannot expose stale transform samples after incremental respawn.
- `74839d9` `fix(#252/T1): defer renderer host fallback clock resolution`
  - Keeps fallback RAF clock lookup out of the constructor.
  - Adds regression coverage for `setAnimationLoop` adapters in runtimes without browser frame globals.
- `a6738eb` `fix(#252/T1): reset renderer host fallback start failure`
  - Rolls back running state when fallback clock resolution or scheduling throws.
  - Adds regression coverage for missing-clock fallback starts.
- `0ed4bb1` `fix(#252/T1): clear renderer loop on start rollback`
  - Clears partially registered renderer-owned animation loops when adapter setup throws.
  - Adds regression coverage for `setAnimationLoop` partial-registration failure.
- `2d0e03e` `fix(#252/T1-T2): address PR 253 review follow-ups`
  - Renamed the renderer-host lifecycle ADR to ADR 0004 and updated guide references.
  - Made `RendererCache` frame application mode explicit, with `applyFrame(...)` as full snapshot mode and `applyIncrementalFrame(...)` for deltas.
  - Hardened `RendererHost` cleanup, rollback warning, handler-failure reporting, fallback restart recovery, and stop/start rescheduling behavior.
  - Added render-core JSDoc/tests, cache/R3F regressions, and lifecycle coverage for the review-requested gaps.

## Verification

- [x] `bun run check`
- [x] `bun test packages/three/tests/renderer-host.test.ts`
- [x] `bun test packages/render-core/tests/frame-ingestion.test.ts`
- [x] `bun test packages/render-core/tests packages/three/tests packages/r3f/tests`
- [x] `cargo check --workspace`

## Reviews

Current state: approved
Last reviewed by: claude/opus-4.7 (claude-code)
Last reviewed at: 2026-05-11T10:33:18Z
Reviewed commit: 2d0e03e3b470bd9614c2d9001d0e23a33351568b
Source artifact: https://github.com/galeon-engine/galeon/pull/253#issuecomment-4419806395
Needs re-review since: —

Prior reviews:
- `claude/opus-4.7 (claude-code)` at 2026-05-11T09:18:35Z on commit `0ed4bb1` — request-changes — https://github.com/galeon-engine/galeon/pull/253#issuecomment-4419193106
- `chatgpt-codex-connector` at 2026-05-11T08:32:34Z on commit `a6738eb` — https://github.com/galeon-engine/galeon/pull/253#pullrequestreview-4261885329

Authored-by: openai/gpt-5 (codex)
Last-code-by: openai/gpt-5 (codex)
Updated-by: claude/opus-4.7 (claude-code)
Edit-kind: review-snapshot
Edit-note: Recorded approve disposition on commit 2d0e03e after verifying C-1, C-2, and I-1..I-4 fixes.
*Captain's log — PR timeline by **shiplog***
