### PR TITLE
feat(#254): encode producer frame extraction mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `TransformFrameIngestion` so authoritative `FramePacket` transforms can be
   buffered and sampled smoothly at render time.
 
+- **Producer-authored frame extraction mode (issue #254)** —
+  `FramePacket` / `WasmFramePacket` now carry explicit `"full"` versus
+  `"incremental"` mode. TypeScript adapters consume this producer mode by
+  default, so empty full snapshots evict stale renderer state while empty
+  incremental deltas preserve unchanged entities without caller-side guessing.
+
 ## [0.5.1] - 2026-05-03
 
 ### Changed

--- a/crates/engine-three-sync/src/extract.rs
+++ b/crates/engine-three-sync/src/extract.rs
@@ -9,7 +9,7 @@ use galeon_engine::{Billboard, Entity, RenderChannelRegistry, RenderEventRegistr
 
 use crate::frame_packet::{
     CHANGED_INSTANCE_GROUP, CHANGED_MATERIAL, CHANGED_MESH, CHANGED_OBJECT_TYPE, CHANGED_PARENT,
-    CHANGED_TINT, CHANGED_TRANSFORM, CHANGED_VISIBILITY, ChannelData, FramePacket,
+    CHANGED_TINT, CHANGED_TRANSFORM, CHANGED_VISIBILITY, ChannelData, FramePacket, FramePacketMode,
     INSTANCE_GROUP_NONE, SCENE_ROOT,
 };
 
@@ -550,6 +550,7 @@ pub fn extract_frame_incremental(world: &World, since_tick: u64) -> FramePacket 
     renderables.sort_by_key(|(entity, ..)| hierarchy_depth(world, *entity, 64));
 
     let mut packet = FramePacket::with_capacity(renderables.len());
+    packet.mode = FramePacketMode::Incremental;
     packet.frame_version = world.change_tick();
 
     for (entity, position, rotation, scale, parent_id, object_type) in &renderables {
@@ -674,6 +675,7 @@ mod tests {
         let world = World::new();
         let packet = extract_frame(&world);
         assert_eq!(packet.entity_count(), 0);
+        assert_eq!(packet.mode, FramePacketMode::Full);
     }
 
     #[test]
@@ -688,6 +690,7 @@ mod tests {
 
         let packet = extract_frame(&world);
         assert_eq!(packet.entity_count(), 1);
+        assert_eq!(packet.mode, FramePacketMode::Full);
         assert_eq!(packet.transforms[0], 1.0);
         assert_eq!(packet.transforms[1], 2.0);
         assert_eq!(packet.transforms[2], 3.0);
@@ -873,6 +876,7 @@ mod tests {
 
         let packet = extract_frame_incremental(&world, since);
         assert_eq!(packet.entity_count(), 0);
+        assert_eq!(packet.mode, FramePacketMode::Incremental);
         assert!(packet.change_flags.is_empty());
     }
 

--- a/crates/engine-three-sync/src/frame_packet.rs
+++ b/crates/engine-three-sync/src/frame_packet.rs
@@ -4,6 +4,25 @@ use std::collections::HashMap;
 
 use galeon_engine::FrameEvent;
 
+/// Producer-authored extraction mode for a [`FramePacket`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FramePacketMode {
+    /// Full scene snapshot: rows are the authoritative active render set.
+    Full,
+    /// Incremental delta: rows are changed entities only.
+    Incremental,
+}
+
+impl FramePacketMode {
+    /// Stable string exposed over the WASM boundary.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Incremental => "incremental",
+        }
+    }
+}
+
 /// Per-channel float data attached to a [`FramePacket`].
 ///
 /// The `data` array is flat: for `n` entities and a stride of `s`, the values
@@ -26,6 +45,8 @@ pub struct ChannelData {
 pub struct FramePacket {
     /// Snapshot contract version shared with TS adapters.
     pub contract_version: u32,
+    /// Producer-authored extraction mode.
+    pub mode: FramePacketMode,
     pub entity_ids: Vec<u32>,
     pub entity_generations: Vec<u32>,
     pub transforms: Vec<f32>,
@@ -106,6 +127,7 @@ impl FramePacket {
     pub fn new() -> Self {
         Self {
             contract_version: RENDER_CONTRACT_VERSION,
+            mode: FramePacketMode::Full,
             entity_ids: Vec::new(),
             entity_generations: Vec::new(),
             transforms: Vec::new(),
@@ -127,6 +149,7 @@ impl FramePacket {
     pub fn with_capacity(entity_count: usize) -> Self {
         Self {
             contract_version: RENDER_CONTRACT_VERSION,
+            mode: FramePacketMode::Full,
             entity_ids: Vec::with_capacity(entity_count),
             entity_generations: Vec::with_capacity(entity_count),
             transforms: Vec::with_capacity(entity_count * TRANSFORM_STRIDE),
@@ -193,6 +216,7 @@ impl FramePacket {
         tint: &[f32; 3],
         flags: u8,
     ) {
+        self.mode = FramePacketMode::Incremental;
         self.push(
             entity_id,
             generation,
@@ -256,6 +280,7 @@ mod tests {
     fn empty_packet() {
         let p = FramePacket::new();
         assert_eq!(p.entity_count(), 0);
+        assert_eq!(p.mode, FramePacketMode::Full);
         assert!(p.entity_ids.is_empty());
         assert_eq!(p.channel_count(), 0);
     }
@@ -384,6 +409,29 @@ mod tests {
         let p2 = FramePacket::with_capacity(10);
         assert_eq!(p2.contract_version, RENDER_CONTRACT_VERSION);
         assert_eq!(p2.frame_version, 0);
+        assert_eq!(p2.mode, FramePacketMode::Full);
+    }
+
+    #[test]
+    fn push_incremental_marks_packet_incremental() {
+        let mut p = FramePacket::new();
+        p.push_incremental(
+            1,
+            0,
+            &[0.0; 3],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[1.0; 3],
+            true,
+            10,
+            20,
+            SCENE_ROOT,
+            0,
+            INSTANCE_GROUP_NONE,
+            &[1.0; 3],
+            CHANGED_TRANSFORM,
+        );
+        assert_eq!(p.mode, FramePacketMode::Incremental);
+        assert_eq!(p.change_flags, vec![CHANGED_TRANSFORM]);
     }
 
     #[test]

--- a/crates/engine-three-sync/src/lib.rs
+++ b/crates/engine-three-sync/src/lib.rs
@@ -7,7 +7,7 @@ mod snapshot;
 pub use extract::{extract_frame, extract_frame_incremental};
 pub use frame_packet::{
     CHANGED_INSTANCE_GROUP, CHANGED_MATERIAL, CHANGED_MESH, CHANGED_OBJECT_TYPE, CHANGED_PARENT,
-    CHANGED_TINT, CHANGED_TRANSFORM, CHANGED_VISIBILITY, ChannelData, FramePacket,
+    CHANGED_TINT, CHANGED_TRANSFORM, CHANGED_VISIBILITY, ChannelData, FramePacket, FramePacketMode,
     INSTANCE_GROUP_NONE, RENDER_CONTRACT_VERSION, SCENE_ROOT, TRANSFORM_STRIDE,
 };
 // Re-export FrameEvent from engine for consumers of this crate.
@@ -354,6 +354,12 @@ impl WasmFramePacket {
     #[wasm_bindgen(getter)]
     pub fn contract_version(&self) -> u32 {
         self.inner.contract_version
+    }
+
+    /// Producer-authored extraction mode: "full" or "incremental".
+    #[wasm_bindgen(getter)]
+    pub fn mode(&self) -> String {
+        self.inner.mode.as_str().to_string()
     }
 
     /// Number of renderable entities in this frame.

--- a/crates/engine-three-sync/tests/consumer_owned_bootstrap.rs
+++ b/crates/engine-three-sync/tests/consumer_owned_bootstrap.rs
@@ -39,6 +39,7 @@ impl DemoWasmEngine {
 
 fn assert_bootstrap_frame(frame: WasmFramePacket) {
     assert_eq!(frame.contract_version(), RENDER_CONTRACT_VERSION);
+    assert_eq!(frame.mode(), "full");
     assert_eq!(frame.entity_count(), 1);
     assert_eq!(frame.mesh_handles(), vec![TEST_MESH_ID]);
     assert_eq!(frame.material_handles(), vec![TEST_MATERIAL_ID]);

--- a/docs/guide/three-sync.md
+++ b/docs/guide/three-sync.md
@@ -49,6 +49,7 @@ ObjectType::Mesh | PointLight | DirectionalLight | LineSegments | Group
 every array refers to the same entity.
 
 ```
+mode:             "full" | "incremental"
 entity_ids:       [u32; N]
 transforms:       [f32; N * 10]   // per entity: pos(3) + rot(4) + scale(3)
 visibility:       [u8;  N]        // 1 = visible, 0 = hidden
@@ -143,12 +144,17 @@ clones the backing `Vec`, which wasm-bindgen converts to a JS typed array
 When present with per-row data, each byte is a bitmask for incremental
 extraction (`extract_frame_incremental`). Empty arrays are valid in both
 full `extract_frame` and no-change incremental snapshots, so packet shape
-alone is not a reliable mode signal. `@galeon/three`'s `RendererCache`
-therefore treats `applyFrame(packet)` as a full snapshot by default. Consumers
-applying deltas must call `applyIncrementalFrame(packet)` or
-`applyFrame(packet, { mode: "incremental" })`; non-empty incremental packets
-must carry one `change_flags` row per entity so the cache can skip redundant
-Three.js writes without treating absence as despawn.
+alone is not a reliable mode signal.
+
+`mode` is the producer-authored extraction mode. Full `extract_frame` packets
+emit `"full"` and incremental `extract_frame_incremental` packets emit
+`"incremental"`, including empty no-change deltas. `@galeon/three`,
+`@galeon/r3f`, and `TransformFrameIngestion` consume this field by default:
+full packets evict absent entities, while incremental packets preserve
+unchanged entities. Non-empty incremental packets must carry one
+`change_flags` row per entity so adapters can skip redundant Three.js writes
+without treating absence as despawn. Legacy/test packets without `mode` are
+treated as full snapshots unless callers explicitly opt into incremental mode.
 
 **MVP transport:** copied flat buffers. Future optimisation: direct typed array
 views into WASM linear memory (zero-copy).

--- a/packages/r3f/src/entity-store.ts
+++ b/packages/r3f/src/entity-store.ts
@@ -4,7 +4,7 @@ import {
   ObjectType,
   SCENE_ROOT,
   TRANSFORM_STRIDE,
-  hasPerRowChangeFlags,
+  framePacketMode,
   type FramePacketView,
 } from "@galeon/render-core";
 import type { RendererCache } from "@galeon/three";
@@ -31,7 +31,7 @@ export class GaleonEntityStore {
   private ordered: GaleonEntityRef[] = [];
 
   sync(packet: FramePacketView, cache: RendererCache): boolean {
-    if (hasPerRowChangeFlags(packet)) {
+    if (framePacketMode(packet) === "incremental") {
       const results = GaleonEntityStore.rowIndexes(packet).map((row) =>
         this.upsertEntity(packet, row, cache),
       );

--- a/packages/r3f/src/entity-store.ts
+++ b/packages/r3f/src/entity-store.ts
@@ -5,6 +5,8 @@ import {
   SCENE_ROOT,
   TRANSFORM_STRIDE,
   framePacketMode,
+  hasPerRowChangeFlags,
+  type FramePacketMode,
   type FramePacketView,
 } from "@galeon/render-core";
 import type { RendererCache } from "@galeon/three";
@@ -31,7 +33,7 @@ export class GaleonEntityStore {
   private ordered: GaleonEntityRef[] = [];
 
   sync(packet: FramePacketView, cache: RendererCache): boolean {
-    if (framePacketMode(packet) === "incremental") {
+    if (GaleonEntityStore.packetMode(packet) === "incremental") {
       const results = GaleonEntityStore.rowIndexes(packet).map((row) =>
         this.upsertEntity(packet, row, cache),
       );
@@ -145,6 +147,14 @@ export class GaleonEntityStore {
 
   private static rowIndexes(packet: FramePacketView): number[] {
     return Array.from({ length: packet.entity_count }, (_, index) => index);
+  }
+
+  private static packetMode(packet: FramePacketView): FramePacketMode {
+    if (packet.mode !== undefined) {
+      return framePacketMode(packet);
+    }
+
+    return hasPerRowChangeFlags(packet) ? "incremental" : "full";
   }
 
   private hasOrderChanged(nextOrder: readonly GaleonEntityRef[]): boolean {

--- a/packages/r3f/tests/entity-store.test.ts
+++ b/packages/r3f/tests/entity-store.test.ts
@@ -106,6 +106,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
     const coldObjectBefore = coldRefBefore.object;
 
     const hotUpdate = makePacket({
+      mode: "incremental",
       entity_count: 1,
       entity_ids: new Uint32Array([1]),
       entity_generations: new Uint32Array([0]),
@@ -113,7 +114,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
     hotUpdate.transforms[0] = 77;
-    cache.applyIncrementalFrame(hotUpdate);
+    cache.applyFrame(hotUpdate);
     expect(store.sync(hotUpdate, cache)).toBe(false);
 
     const hotRef = store.get(1, 0)!;
@@ -138,17 +139,45 @@ describe("GaleonEntityStore hot-update behavior", () => {
     const entitiesBefore = store.entities();
 
     const incrementalSpawn = makePacket({
+      mode: "incremental",
       entity_count: 1,
       entity_ids: new Uint32Array([2]),
       entity_generations: new Uint32Array([0]),
       frame_version: 2n,
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
-    cache.applyIncrementalFrame(incrementalSpawn);
+    cache.applyFrame(incrementalSpawn);
     expect(store.sync(incrementalSpawn, cache)).toBe(true);
 
     expect(store.entities()).not.toBe(entitiesBefore);
     expect(store.entities().map((entity) => entity.entityId)).toEqual([1, 2]);
+  });
+
+  test("empty producer incremental packets keep existing entity refs", () => {
+    const cache = new RendererCache(new THREE.Scene());
+    const store = new GaleonEntityStore();
+
+    const fullFrame = makePacket({
+      entity_count: 1,
+      entity_ids: new Uint32Array([1]),
+      entity_generations: new Uint32Array([0]),
+      frame_version: 1n,
+    });
+    cache.applyFrame(fullFrame);
+    expect(store.sync(fullFrame, cache)).toBe(true);
+    const refBefore = store.get(1, 0)!;
+
+    const emptyIncremental = makePacket({
+      mode: "incremental",
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+      frame_version: 2n,
+    });
+    cache.applyFrame(emptyIncremental);
+    expect(store.sync(emptyIncremental, cache)).toBe(false);
+
+    expect(store.get(1, 0)).toBe(refBefore);
+    expect(store.entities()).toEqual([refBefore]);
   });
 
   test("object type changes are structural when the Three object identity changes", () => {
@@ -169,6 +198,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
     expect(meshObject).toBeInstanceOf(THREE.Mesh);
 
     const lightFrame = makePacket({
+      mode: "incremental",
       entity_count: 1,
       entity_ids: new Uint32Array([1]),
       entity_generations: new Uint32Array([0]),
@@ -176,7 +206,7 @@ describe("GaleonEntityStore hot-update behavior", () => {
       change_flags: new Uint8Array([CHANGED_OBJECT_TYPE]),
       frame_version: 2n,
     });
-    cache.applyIncrementalFrame(lightFrame);
+    cache.applyFrame(lightFrame);
     expect(store.sync(lightFrame, cache)).toBe(true);
 
     expect(store.entities()).not.toBe(entitiesBefore);

--- a/packages/r3f/tests/entity-store.test.ts
+++ b/packages/r3f/tests/entity-store.test.ts
@@ -124,6 +124,37 @@ describe("GaleonEntityStore hot-update behavior", () => {
     expect(coldRefAfter.object).toBe(coldObjectBefore);
   });
 
+  test("mode-less packets with row flags remain incremental for legacy callers", () => {
+    const cache = new RendererCache(new THREE.Scene());
+    const store = new GaleonEntityStore();
+
+    const fullFrame = makePacket({
+      entity_count: 2,
+      entity_ids: new Uint32Array([1, 2]),
+      entity_generations: new Uint32Array([0, 0]),
+      frame_version: 1n,
+    });
+    cache.applyFrame(fullFrame);
+    expect(store.sync(fullFrame, cache)).toBe(true);
+
+    const coldRefBefore = store.get(2, 0)!;
+
+    const legacyIncremental = makePacket({
+      entity_count: 1,
+      entity_ids: new Uint32Array([1]),
+      entity_generations: new Uint32Array([0]),
+      frame_version: 2n,
+      change_flags: new Uint8Array([CHANGED_TRANSFORM]),
+    });
+    legacyIncremental.transforms[0] = 88;
+    cache.applyIncrementalFrame(legacyIncremental);
+    expect(store.sync(legacyIncremental, cache)).toBe(false);
+
+    expect(store.get(1, 0)!.transform[0]).toBe(88);
+    expect(store.get(2, 0)).toBe(coldRefBefore);
+    expect(store.entities().map((entity) => entity.entityId)).toEqual([1, 2]);
+  });
+
   test("incremental structural additions publish a new entities array", () => {
     const cache = new RendererCache(new THREE.Scene());
     const store = new GaleonEntityStore();

--- a/packages/render-core/src/frame-ingestion.ts
+++ b/packages/render-core/src/frame-ingestion.ts
@@ -5,6 +5,8 @@ import {
   FramePacketContractError,
   TRANSFORM_STRIDE,
   assertFramePacketContract,
+  framePacketMode,
+  type FramePacketMode,
   type FramePacketView,
 } from "./index.js";
 
@@ -191,7 +193,7 @@ export interface TransformFrameIngestionOptions {
   readonly maxHistoryMs?: number;
 }
 
-export type TransformFrameIngestionMode = "full" | "incremental";
+export type TransformFrameIngestionMode = FramePacketMode;
 
 export interface TransformFrameIngestOptions {
   readonly mode?: TransformFrameIngestionMode;
@@ -250,7 +252,7 @@ export class TransformFrameIngestion {
     receivedAtMs = this.now(),
     options: TransformFrameIngestOptions = {},
   ): void {
-    const mode = options.mode ?? "full";
+    const mode = options.mode ?? framePacketMode(packet);
     const isIncremental = mode === "incremental";
     if (isIncremental && packet.entity_count > 0) {
       const flagCount = packet.change_flags?.length ?? 0;

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -3,6 +3,9 @@
 /** Render snapshot contract version shared across Rust/WASM and TypeScript consumers. */
 export const RENDER_CONTRACT_VERSION = 1;
 
+/** Producer-authored extraction mode emitted by Rust. */
+export type FramePacketMode = "full" | "incremental";
+
 /** Bitmasks for incremental frame rows; values match Rust `galeon_engine_three_sync::frame_packet`. */
 export const CHANGED_TRANSFORM = 1 << 0;
 /** Visibility changed — matches Rust `CHANGED_VISIBILITY`. */
@@ -53,6 +56,14 @@ export interface FramePacketView {
    * Omitted only for legacy packets produced before contract versioning.
    */
   readonly contract_version?: number;
+  /**
+   * Producer-authored extraction mode.
+   *
+   * Omitted only for legacy/test packet shapes. Real `WasmFramePacket` values
+   * expose `"full"` for authoritative snapshots and `"incremental"` for
+   * delta packets, including empty no-change deltas.
+   */
+  readonly mode?: FramePacketMode;
   readonly entity_count: number;
   readonly entity_ids: Uint32Array;
   readonly entity_generations: Uint32Array;
@@ -149,6 +160,20 @@ export class FramePacketContractError extends Error {
   }
 }
 
+/** Return the producer-authored packet mode, defaulting legacy packets to full snapshots. */
+export function framePacketMode(
+  packet: FramePacketView,
+  fallback: FramePacketMode = "full",
+): FramePacketMode {
+  const mode = packet.mode ?? fallback;
+  if (mode !== "full" && mode !== "incremental") {
+    throw new FramePacketContractError(
+      `unsupported frame packet mode "${String(mode)}"`,
+    );
+  }
+  return mode;
+}
+
 function assertLength(
   field: string,
   actual: number,
@@ -236,7 +261,11 @@ export function assertFramePacketContract(
     assertLength("tints", packet.tints.length, entityCount * 3);
   }
 
-  if (packet.change_flags !== undefined && packet.change_flags.length > 0) {
+  const mode = framePacketMode(packet);
+  if (mode === "incremental" && entityCount > 0) {
+    const flagCount = packet.change_flags?.length ?? 0;
+    assertLength("change_flags", flagCount, entityCount);
+  } else if (packet.change_flags !== undefined && packet.change_flags.length > 0) {
     assertLength("change_flags", packet.change_flags.length, entityCount);
   }
 

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -61,9 +61,11 @@ export interface FramePacketView {
    *
    * Omitted only for legacy/test packet shapes. Real `WasmFramePacket` values
    * expose `"full"` for authoritative snapshots and `"incremental"` for
-   * delta packets, including empty no-change deltas.
+   * delta packets, including empty no-change deltas. wasm-bindgen types those
+   * string getters as `string`; `framePacketMode(...)` validates the raw
+   * producer value before consumers branch on it.
    */
-  readonly mode?: FramePacketMode;
+  readonly mode?: FramePacketMode | string;
   readonly entity_count: number;
   readonly entity_ids: Uint32Array;
   readonly entity_generations: Uint32Array;

--- a/packages/render-core/tests/contract.test.ts
+++ b/packages/render-core/tests/contract.test.ts
@@ -6,6 +6,7 @@ import {
   SCENE_ROOT,
   TRANSFORM_STRIDE,
   assertFramePacketContract,
+  framePacketMode,
   type FramePacketView,
 } from "../src/index.js";
 
@@ -68,5 +69,32 @@ describe("render-core contract checks", () => {
         allowMissingContractVersion: false,
       }),
     ).toThrow("missing contract_version");
+  });
+
+  test("producer mode defaults legacy packets to full", () => {
+    const packet = makePacket({ entity_count: 0 });
+
+    expect(framePacketMode(packet)).toBe("full");
+  });
+
+  test("incremental mode requires one change flag per emitted row", () => {
+    const packet = makePacket({
+      mode: "incremental",
+      entity_count: 1,
+      change_flags: new Uint8Array(0),
+    });
+
+    expect(() => assertFramePacketContract(packet)).toThrow("change_flags");
+  });
+
+  test("empty incremental packets are valid no-change deltas", () => {
+    const packet = makePacket({
+      mode: "incremental",
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+    });
+
+    expect(() => assertFramePacketContract(packet)).not.toThrow();
+    expect(framePacketMode(packet)).toBe("incremental");
   });
 });

--- a/packages/render-core/tests/contract.test.ts
+++ b/packages/render-core/tests/contract.test.ts
@@ -77,6 +77,16 @@ describe("render-core contract checks", () => {
     expect(framePacketMode(packet)).toBe("full");
   });
 
+  test("accepts wasm-bindgen string-typed mode getters", () => {
+    const packet = makePacket({
+      mode: "full" as string,
+      entity_count: 0,
+    });
+
+    expect(() => assertFramePacketContract(packet)).not.toThrow();
+    expect(framePacketMode(packet)).toBe("full");
+  });
+
   test("incremental mode requires one change flag per emitted row", () => {
     const packet = makePacket({
       mode: "incremental",

--- a/packages/render-core/tests/frame-ingestion.test.ts
+++ b/packages/render-core/tests/frame-ingestion.test.ts
@@ -178,12 +178,13 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(full, 0);
 
     const incremental = makePacket({
+      mode: "incremental",
       entity_count: 1,
       change_flags: new Uint8Array([CHANGED_MATERIAL]),
     });
     incremental.entity_ids[0] = 2;
     setTransform(incremental, 0, 4);
-    ingestion.ingestIncrementalFrame(incremental, 16);
+    ingestion.ingestFrame(incremental, 16);
 
     expect(ingestion.sampleEntity(1, 0, 16)?.x).toBe(3);
 
@@ -205,10 +206,11 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(full, 0);
 
     const emptyIncremental = makePacket({
+      mode: "incremental",
       entity_count: 0,
       change_flags: new Uint8Array(0),
     });
-    ingestion.ingestIncrementalFrame(emptyIncremental, 16);
+    ingestion.ingestFrame(emptyIncremental, 16);
 
     expect(ingestion.sampleEntity(3, 0, 16)?.x).toBe(9);
   });
@@ -245,18 +247,15 @@ describe("TransformFrameIngestion", () => {
     });
 
     const malformed = makePacket({
+      mode: "incremental",
       entity_count: 1,
       change_flags: new Uint8Array(0),
     });
     malformed.entity_ids[0] = 8;
     setTransform(malformed, 0, 1);
 
-    expect(() => assertFramePacketContract(malformed)).not.toThrow();
-    expect(
-      () => ingestion.ingestFrame(malformed, 0, { mode: "incremental" }),
-    ).toThrow(
-      /change_flags/i,
-    );
+    expect(() => assertFramePacketContract(malformed)).toThrow(/change_flags/i);
+    expect(() => ingestion.ingestFrame(malformed, 0)).toThrow(/change_flags/i);
   });
 
   test("incremental transform changes add new samples", () => {
@@ -270,12 +269,13 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(first, 0);
 
     const incremental = makePacket({
+      mode: "incremental",
       entity_count: 1,
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
     incremental.entity_ids[0] = 9;
     setTransform(incremental, 0, 20);
-    ingestion.ingestIncrementalFrame(incremental, 100);
+    ingestion.ingestFrame(incremental, 100);
 
     expect(ingestion.sampleEntity(9, 0, 25)?.x).toBe(5);
   });
@@ -292,13 +292,14 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(full, 0);
 
     const incremental = makePacket({
+      mode: "incremental",
       entity_count: 1,
       change_flags: new Uint8Array([CHANGED_VISIBILITY]),
     });
     incremental.entity_ids[0] = 4;
     incremental.visibility[0] = 0;
     setTransform(incremental, 0, 1);
-    ingestion.ingestIncrementalFrame(incremental, 50);
+    ingestion.ingestFrame(incremental, 50);
 
     expect(ingestion.sampleFrame(50)[0]?.visible).toBe(false);
   });
@@ -338,13 +339,14 @@ describe("TransformFrameIngestion", () => {
     ingestion.ingestFrame(first, 0);
 
     const rollover = makePacket({
+      mode: "incremental",
       entity_count: 1,
       change_flags: new Uint8Array([CHANGED_TRANSFORM]),
     });
     rollover.entity_ids[0] = 12;
     rollover.entity_generations[0] = 2;
     setTransform(rollover, 0, 6);
-    ingestion.ingestIncrementalFrame(rollover, 16);
+    ingestion.ingestFrame(rollover, 16);
 
     expect(ingestion.sampleEntity(12, 1, 16)).toBeUndefined();
     expect(ingestion.sampleEntity(12, 2, 16)?.x).toBe(6);

--- a/packages/three/src/renderer-cache.ts
+++ b/packages/three/src/renderer-cache.ts
@@ -10,6 +10,8 @@ import {
   FramePacketContractError,
   INSTANCE_GROUP_NONE,
   assertFramePacketContract,
+  framePacketMode,
+  type FramePacketMode,
   type FramePacketView,
   ObjectType,
   SCENE_ROOT,
@@ -53,7 +55,7 @@ export interface RendererCacheOptions {
   readonly instancing?: InstancedMeshManagerOptions;
 }
 
-export type RendererCacheFrameMode = "full" | "incremental";
+export type RendererCacheFrameMode = FramePacketMode;
 
 export interface RendererCacheApplyOptions {
   readonly mode?: RendererCacheFrameMode;
@@ -158,7 +160,7 @@ export class RendererCache {
   ): void {
     assertFramePacketContract(packet);
 
-    const mode = options.mode ?? "full";
+    const mode = options.mode ?? framePacketMode(packet);
     const isIncremental = mode === "incremental";
     if (isIncremental && packet.entity_count > 0) {
       const flagCount = packet.change_flags?.length ?? 0;

--- a/packages/three/tests/contract-guardrails.test.ts
+++ b/packages/three/tests/contract-guardrails.test.ts
@@ -62,4 +62,57 @@ describe("RendererCache render contract guardrails", () => {
 
     expect(() => cache.applyFrame(packet)).not.toThrow();
   });
+
+  test("producer full mode evicts stale entities even with empty change flags", () => {
+    const cache = new RendererCache(new THREE.Scene());
+    const baseline = makePacket({
+      entity_count: 1,
+      entity_ids: new Uint32Array([7]),
+      entity_generations: new Uint32Array([0]),
+      frame_version: 1n,
+    });
+    baseline.transforms[6] = 1;
+    baseline.transforms[7] = 1;
+    baseline.transforms[8] = 1;
+    baseline.transforms[9] = 1;
+    cache.applyFrame(baseline);
+    expect(cache.objectCount).toBe(1);
+
+    const emptyFull = makePacket({
+      mode: "full",
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+      frame_version: 2n,
+    });
+    cache.applyFrame(emptyFull);
+
+    expect(cache.objectCount).toBe(0);
+  });
+
+  test("producer incremental empty packets preserve unchanged entities", () => {
+    const cache = new RendererCache(new THREE.Scene());
+    const baseline = makePacket({
+      entity_count: 1,
+      entity_ids: new Uint32Array([7]),
+      entity_generations: new Uint32Array([0]),
+      frame_version: 1n,
+    });
+    baseline.transforms[6] = 1;
+    baseline.transforms[7] = 1;
+    baseline.transforms[8] = 1;
+    baseline.transforms[9] = 1;
+    cache.applyFrame(baseline);
+    expect(cache.objectCount).toBe(1);
+
+    const emptyIncremental = makePacket({
+      mode: "incremental",
+      entity_count: 0,
+      change_flags: new Uint8Array(0),
+      frame_version: 2n,
+    });
+    cache.applyFrame(emptyIncremental);
+
+    expect(cache.objectCount).toBe(1);
+    expect(cache.getObject(7, 0)).toBeDefined();
+  });
 });


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 254
branch: issue/254-frame-extraction-mode
status: resolved
updated_at: 2026-05-11T12:00:52Z
review_status: approved
-->

## Summary

This PR encodes the producer-authored frame extraction mode in Galeon's Rust/WASM frame packet contract and exposes that mode through the TypeScript render boundary. It removes caller-side guessing for full snapshots versus incremental deltas, so empty full packets can evict stale render state while empty incremental packets preserve unchanged state.

Closes #254

## Review Status

- **Current state:** approved
- **Last reviewed by:** chatgpt-codex-connector
- **Last reviewed at:** 2026-05-11T11:55:04Z
- **Reviewed commit:** df3e77b
- **Source artifact:** https://github.com/galeon-engine/galeon/pull/255#issuecomment-4420435587
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan

#254 was opened after #252 / PR #253 found that change_flags alone could not distinguish full snapshots from incremental no-change ticks. The goal was to move the discriminator to the Rust/WASM producer boundary and update TypeScript consumers to honor that mode.

### What We Discovered

- Real WASM packets can expose empty change_flags for more than one semantic case, so payload-shape inference is not reliable.
- The renderer cache, R3F entity store, and frame ingestion path all need to consume the same producer-authored mode rather than each inventing local policy.
- A fresh worktree needed un install before Three-backed package tests could resolve dependencies; no code workaround was required.

### Implementation Issues

- The implementation preserved the existing packet shape where practical while adding explicit frame mode metadata and validation around malformed incremental row flags.
- Consumer updates had to cover both full empty worlds and empty incremental deltas to prove the old ambiguous wire shape no longer drives behavior.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Frame mode source | Producer-authored mode on the frame packet contract | Consumers cannot safely infer mode from change_flags presence or emptiness. |
| Consumer behavior | Renderer/R3F/frame-ingestion branch on packet mode | Keeps full snapshot eviction and incremental preservation consistent across adapters. |
| Regression shape | Cover empty full, empty incremental, and row-flagged incremental packets | These are the cases that previously collapsed into ambiguous arrays. |

### Changes Made

**Commits:**

- 5e3ecd8 feat(#254/T1-T3): encode producer frame extraction mode
- f8f5333 fix(#254): accept wasm-bindgen frame mode strings
- df3e77b fix(#254): preserve legacy r3f incremental sync

## Testing

- [x] cargo fmt --check
- [x] cargo test -p galeon-engine-three-sync
- [x] cargo check --workspace
- [x] cargo check -p galeon-engine-three-sync
- [x] cargo check --target wasm32-unknown-unknown -p galeon-engine-three-sync
- [x] cargo clippy --workspace -- -D warnings
- [x] un run check
- [x] un run build
- [x] un test
- [x] Focused packet-mode regression tests for full and incremental extraction semantics
- [x] ash tests/local-first-starter-smoke.sh after CI exposed wasm-bindgen's string-typed mode getter
- [x] un test packages/r3f/tests/entity-store.test.ts for the PR #255 legacy incremental review fix

**Verification summary:** Added and updated Rust/WASM, render-core, Three, and R3F coverage around producer mode, contract validation, renderer cache application, entity-store behavior, and ambiguous empty packet shapes.

## Stacked PRs / Related

- Discovered from #252 / PR #253 review work.
- Unblocks continuing #252 T3/T4/T5 with the frame mode contract settled.

## Knowledge for Future Reference

Do not reintroduce packet-shape inference for full versus incremental frame semantics. If additional extraction modes are added later, extend the producer-authored frame mode contract and adapter validation instead of teaching TypeScript consumers to infer intent from optional or empty arrays.

---
Authored-by: openai/gpt-5 (codex; orchestrator)
Last-code-by: openai/gpt-5 (codex; orchestrator)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*




